### PR TITLE
Replace base image with alpine/git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git
 
-MAINTAINER Caleb Washburn "cwashburn@pivotal.io"
+LABEL maintainer="Caleb Washburn cwashburn@pivotal.io"
 
 COPY cf-mgmt-linux /usr/bin/cf-mgmt
 COPY cf-mgmt-config-linux /usr/bin/cf-mgmt-config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM concourse/buildroot:git
+FROM alpine/git
 
 MAINTAINER Caleb Washburn "cwashburn@pivotal.io"
 


### PR DESCRIPTION
I tried to use the cf-mgmt image for some user-management-tasks and found out that the base image is kind of old/[deprecated](https://github.com/concourse/buildroot-images) (>3years). For me it led to some difficulties, since I needed a newer git-version.

In my understanding, the `concourse/buildroot:git` image just contained some kind of self-compiled git version which is why I thought `alpine/git` would be a sufficient and more up-to-date replacement.

**However, I did not test these changes!**
Maybe some maintainer could do this before merging.

PS: Since my editor threw some deprecation warnings, I additionally replaced the MAINTAINER instruction with a label as proposed in the [official Docker documentation](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated).
