### PR TITLE
Export Space Metadata

### DIFF
--- a/config/fakes/fake_manager.go
+++ b/config/fakes/fake_manager.go
@@ -492,15 +492,16 @@ func (fake *FakeManager) AddDefaultSecurityGroup(arg1 string, arg2 []byte) error
 		arg1 string
 		arg2 []byte
 	}{arg1, arg2Copy})
+	stub := fake.AddDefaultSecurityGroupStub
+	fakeReturns := fake.addDefaultSecurityGroupReturns
 	fake.recordInvocation("AddDefaultSecurityGroup", []interface{}{arg1, arg2Copy})
 	fake.addDefaultSecurityGroupMutex.Unlock()
-	if fake.AddDefaultSecurityGroupStub != nil {
-		return fake.AddDefaultSecurityGroupStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addDefaultSecurityGroupReturns
 	return fakeReturns.result1
 }
 
@@ -552,15 +553,16 @@ func (fake *FakeManager) AddOrgQuota(arg1 config.OrgQuota) error {
 	fake.addOrgQuotaArgsForCall = append(fake.addOrgQuotaArgsForCall, struct {
 		arg1 config.OrgQuota
 	}{arg1})
+	stub := fake.AddOrgQuotaStub
+	fakeReturns := fake.addOrgQuotaReturns
 	fake.recordInvocation("AddOrgQuota", []interface{}{arg1})
 	fake.addOrgQuotaMutex.Unlock()
-	if fake.AddOrgQuotaStub != nil {
-		return fake.AddOrgQuotaStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addOrgQuotaReturns
 	return fakeReturns.result1
 }
 
@@ -612,15 +614,16 @@ func (fake *FakeManager) AddOrgToConfig(arg1 *config.OrgConfig) error {
 	fake.addOrgToConfigArgsForCall = append(fake.addOrgToConfigArgsForCall, struct {
 		arg1 *config.OrgConfig
 	}{arg1})
+	stub := fake.AddOrgToConfigStub
+	fakeReturns := fake.addOrgToConfigReturns
 	fake.recordInvocation("AddOrgToConfig", []interface{}{arg1})
 	fake.addOrgToConfigMutex.Unlock()
-	if fake.AddOrgToConfigStub != nil {
-		return fake.AddOrgToConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addOrgToConfigReturns
 	return fakeReturns.result1
 }
 
@@ -678,15 +681,16 @@ func (fake *FakeManager) AddSecurityGroup(arg1 string, arg2 []byte) error {
 		arg1 string
 		arg2 []byte
 	}{arg1, arg2Copy})
+	stub := fake.AddSecurityGroupStub
+	fakeReturns := fake.addSecurityGroupReturns
 	fake.recordInvocation("AddSecurityGroup", []interface{}{arg1, arg2Copy})
 	fake.addSecurityGroupMutex.Unlock()
-	if fake.AddSecurityGroupStub != nil {
-		return fake.AddSecurityGroupStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addSecurityGroupReturns
 	return fakeReturns.result1
 }
 
@@ -745,15 +749,16 @@ func (fake *FakeManager) AddSecurityGroupToSpace(arg1 string, arg2 string, arg3 
 		arg2 string
 		arg3 []byte
 	}{arg1, arg2, arg3Copy})
+	stub := fake.AddSecurityGroupToSpaceStub
+	fakeReturns := fake.addSecurityGroupToSpaceReturns
 	fake.recordInvocation("AddSecurityGroupToSpace", []interface{}{arg1, arg2, arg3Copy})
 	fake.addSecurityGroupToSpaceMutex.Unlock()
-	if fake.AddSecurityGroupToSpaceStub != nil {
-		return fake.AddSecurityGroupToSpaceStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addSecurityGroupToSpaceReturns
 	return fakeReturns.result1
 }
 
@@ -805,15 +810,16 @@ func (fake *FakeManager) AddSpaceQuota(arg1 config.SpaceQuota) error {
 	fake.addSpaceQuotaArgsForCall = append(fake.addSpaceQuotaArgsForCall, struct {
 		arg1 config.SpaceQuota
 	}{arg1})
+	stub := fake.AddSpaceQuotaStub
+	fakeReturns := fake.addSpaceQuotaReturns
 	fake.recordInvocation("AddSpaceQuota", []interface{}{arg1})
 	fake.addSpaceQuotaMutex.Unlock()
-	if fake.AddSpaceQuotaStub != nil {
-		return fake.AddSpaceQuotaStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addSpaceQuotaReturns
 	return fakeReturns.result1
 }
 
@@ -865,15 +871,16 @@ func (fake *FakeManager) AddSpaceToConfig(arg1 *config.SpaceConfig) error {
 	fake.addSpaceToConfigArgsForCall = append(fake.addSpaceToConfigArgsForCall, struct {
 		arg1 *config.SpaceConfig
 	}{arg1})
+	stub := fake.AddSpaceToConfigStub
+	fakeReturns := fake.addSpaceToConfigReturns
 	fake.recordInvocation("AddSpaceToConfig", []interface{}{arg1})
 	fake.addSpaceToConfigMutex.Unlock()
-	if fake.AddSpaceToConfigStub != nil {
-		return fake.AddSpaceToConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addSpaceToConfigReturns
 	return fakeReturns.result1
 }
 
@@ -927,15 +934,16 @@ func (fake *FakeManager) AssociateOrgAuditor(arg1 config.UserOrigin, arg2 string
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.AssociateOrgAuditorStub
+	fakeReturns := fake.associateOrgAuditorReturns
 	fake.recordInvocation("AssociateOrgAuditor", []interface{}{arg1, arg2, arg3})
 	fake.associateOrgAuditorMutex.Unlock()
-	if fake.AssociateOrgAuditorStub != nil {
-		return fake.AssociateOrgAuditorStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.associateOrgAuditorReturns
 	return fakeReturns.result1
 }
 
@@ -990,15 +998,16 @@ func (fake *FakeManager) AssociateSpaceAuditor(arg1 config.UserOrigin, arg2 stri
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.AssociateSpaceAuditorStub
+	fakeReturns := fake.associateSpaceAuditorReturns
 	fake.recordInvocation("AssociateSpaceAuditor", []interface{}{arg1, arg2, arg3, arg4})
 	fake.associateSpaceAuditorMutex.Unlock()
-	if fake.AssociateSpaceAuditorStub != nil {
-		return fake.AssociateSpaceAuditorStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.associateSpaceAuditorReturns
 	return fakeReturns.result1
 }
 
@@ -1053,15 +1062,16 @@ func (fake *FakeManager) AssociateSpaceDeveloper(arg1 config.UserOrigin, arg2 st
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.AssociateSpaceDeveloperStub
+	fakeReturns := fake.associateSpaceDeveloperReturns
 	fake.recordInvocation("AssociateSpaceDeveloper", []interface{}{arg1, arg2, arg3, arg4})
 	fake.associateSpaceDeveloperMutex.Unlock()
-	if fake.AssociateSpaceDeveloperStub != nil {
-		return fake.AssociateSpaceDeveloperStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.associateSpaceDeveloperReturns
 	return fakeReturns.result1
 }
 
@@ -1113,15 +1123,16 @@ func (fake *FakeManager) CreateConfigIfNotExists(arg1 string) error {
 	fake.createConfigIfNotExistsArgsForCall = append(fake.createConfigIfNotExistsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.CreateConfigIfNotExistsStub
+	fakeReturns := fake.createConfigIfNotExistsReturns
 	fake.recordInvocation("CreateConfigIfNotExists", []interface{}{arg1})
 	fake.createConfigIfNotExistsMutex.Unlock()
-	if fake.CreateConfigIfNotExistsStub != nil {
-		return fake.CreateConfigIfNotExistsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createConfigIfNotExistsReturns
 	return fakeReturns.result1
 }
 
@@ -1172,15 +1183,16 @@ func (fake *FakeManager) DeleteConfigIfExists() error {
 	ret, specificReturn := fake.deleteConfigIfExistsReturnsOnCall[len(fake.deleteConfigIfExistsArgsForCall)]
 	fake.deleteConfigIfExistsArgsForCall = append(fake.deleteConfigIfExistsArgsForCall, struct {
 	}{})
+	stub := fake.DeleteConfigIfExistsStub
+	fakeReturns := fake.deleteConfigIfExistsReturns
 	fake.recordInvocation("DeleteConfigIfExists", []interface{}{})
 	fake.deleteConfigIfExistsMutex.Unlock()
-	if fake.DeleteConfigIfExistsStub != nil {
-		return fake.DeleteConfigIfExistsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteConfigIfExistsReturns
 	return fakeReturns.result1
 }
 
@@ -1225,15 +1237,16 @@ func (fake *FakeManager) DeleteOrgConfig(arg1 string) error {
 	fake.deleteOrgConfigArgsForCall = append(fake.deleteOrgConfigArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.DeleteOrgConfigStub
+	fakeReturns := fake.deleteOrgConfigReturns
 	fake.recordInvocation("DeleteOrgConfig", []interface{}{arg1})
 	fake.deleteOrgConfigMutex.Unlock()
-	if fake.DeleteOrgConfigStub != nil {
-		return fake.DeleteOrgConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteOrgConfigReturns
 	return fakeReturns.result1
 }
 
@@ -1286,15 +1299,16 @@ func (fake *FakeManager) DeleteSpaceConfig(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.DeleteSpaceConfigStub
+	fakeReturns := fake.deleteSpaceConfigReturns
 	fake.recordInvocation("DeleteSpaceConfig", []interface{}{arg1, arg2})
 	fake.deleteSpaceConfigMutex.Unlock()
-	if fake.DeleteSpaceConfigStub != nil {
-		return fake.DeleteSpaceConfigStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteSpaceConfigReturns
 	return fakeReturns.result1
 }
 
@@ -1345,15 +1359,16 @@ func (fake *FakeManager) GetASGConfigs() ([]config.ASGConfig, error) {
 	ret, specificReturn := fake.getASGConfigsReturnsOnCall[len(fake.getASGConfigsArgsForCall)]
 	fake.getASGConfigsArgsForCall = append(fake.getASGConfigsArgsForCall, struct {
 	}{})
+	stub := fake.GetASGConfigsStub
+	fakeReturns := fake.getASGConfigsReturns
 	fake.recordInvocation("GetASGConfigs", []interface{}{})
 	fake.getASGConfigsMutex.Unlock()
-	if fake.GetASGConfigsStub != nil {
-		return fake.GetASGConfigsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getASGConfigsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1400,15 +1415,16 @@ func (fake *FakeManager) GetDefaultASGConfigs() ([]config.ASGConfig, error) {
 	ret, specificReturn := fake.getDefaultASGConfigsReturnsOnCall[len(fake.getDefaultASGConfigsArgsForCall)]
 	fake.getDefaultASGConfigsArgsForCall = append(fake.getDefaultASGConfigsArgsForCall, struct {
 	}{})
+	stub := fake.GetDefaultASGConfigsStub
+	fakeReturns := fake.getDefaultASGConfigsReturns
 	fake.recordInvocation("GetDefaultASGConfigs", []interface{}{})
 	fake.getDefaultASGConfigsMutex.Unlock()
-	if fake.GetDefaultASGConfigsStub != nil {
-		return fake.GetDefaultASGConfigsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getDefaultASGConfigsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1455,15 +1471,16 @@ func (fake *FakeManager) GetGlobalConfig() (*config.GlobalConfig, error) {
 	ret, specificReturn := fake.getGlobalConfigReturnsOnCall[len(fake.getGlobalConfigArgsForCall)]
 	fake.getGlobalConfigArgsForCall = append(fake.getGlobalConfigArgsForCall, struct {
 	}{})
+	stub := fake.GetGlobalConfigStub
+	fakeReturns := fake.getGlobalConfigReturns
 	fake.recordInvocation("GetGlobalConfig", []interface{}{})
 	fake.getGlobalConfigMutex.Unlock()
-	if fake.GetGlobalConfigStub != nil {
-		return fake.GetGlobalConfigStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getGlobalConfigReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1511,15 +1528,16 @@ func (fake *FakeManager) GetOrgConfig(arg1 string) (*config.OrgConfig, error) {
 	fake.getOrgConfigArgsForCall = append(fake.getOrgConfigArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetOrgConfigStub
+	fakeReturns := fake.getOrgConfigReturns
 	fake.recordInvocation("GetOrgConfig", []interface{}{arg1})
 	fake.getOrgConfigMutex.Unlock()
-	if fake.GetOrgConfigStub != nil {
-		return fake.GetOrgConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getOrgConfigReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1573,15 +1591,16 @@ func (fake *FakeManager) GetOrgConfigs() ([]config.OrgConfig, error) {
 	ret, specificReturn := fake.getOrgConfigsReturnsOnCall[len(fake.getOrgConfigsArgsForCall)]
 	fake.getOrgConfigsArgsForCall = append(fake.getOrgConfigsArgsForCall, struct {
 	}{})
+	stub := fake.GetOrgConfigsStub
+	fakeReturns := fake.getOrgConfigsReturns
 	fake.recordInvocation("GetOrgConfigs", []interface{}{})
 	fake.getOrgConfigsMutex.Unlock()
-	if fake.GetOrgConfigsStub != nil {
-		return fake.GetOrgConfigsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getOrgConfigsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1629,15 +1648,16 @@ func (fake *FakeManager) GetOrgQuota(arg1 string) (*config.OrgQuota, error) {
 	fake.getOrgQuotaArgsForCall = append(fake.getOrgQuotaArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetOrgQuotaStub
+	fakeReturns := fake.getOrgQuotaReturns
 	fake.recordInvocation("GetOrgQuota", []interface{}{arg1})
 	fake.getOrgQuotaMutex.Unlock()
-	if fake.GetOrgQuotaStub != nil {
-		return fake.GetOrgQuotaStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getOrgQuotaReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1691,15 +1711,16 @@ func (fake *FakeManager) GetOrgQuotas() ([]config.OrgQuota, error) {
 	ret, specificReturn := fake.getOrgQuotasReturnsOnCall[len(fake.getOrgQuotasArgsForCall)]
 	fake.getOrgQuotasArgsForCall = append(fake.getOrgQuotasArgsForCall, struct {
 	}{})
+	stub := fake.GetOrgQuotasStub
+	fakeReturns := fake.getOrgQuotasReturns
 	fake.recordInvocation("GetOrgQuotas", []interface{}{})
 	fake.getOrgQuotasMutex.Unlock()
-	if fake.GetOrgQuotasStub != nil {
-		return fake.GetOrgQuotasStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getOrgQuotasReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1748,15 +1769,16 @@ func (fake *FakeManager) GetSpaceConfig(arg1 string, arg2 string) (*config.Space
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetSpaceConfigStub
+	fakeReturns := fake.getSpaceConfigReturns
 	fake.recordInvocation("GetSpaceConfig", []interface{}{arg1, arg2})
 	fake.getSpaceConfigMutex.Unlock()
-	if fake.GetSpaceConfigStub != nil {
-		return fake.GetSpaceConfigStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSpaceConfigReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1810,15 +1832,16 @@ func (fake *FakeManager) GetSpaceConfigs() ([]config.SpaceConfig, error) {
 	ret, specificReturn := fake.getSpaceConfigsReturnsOnCall[len(fake.getSpaceConfigsArgsForCall)]
 	fake.getSpaceConfigsArgsForCall = append(fake.getSpaceConfigsArgsForCall, struct {
 	}{})
+	stub := fake.GetSpaceConfigsStub
+	fakeReturns := fake.getSpaceConfigsReturns
 	fake.recordInvocation("GetSpaceConfigs", []interface{}{})
 	fake.getSpaceConfigsMutex.Unlock()
-	if fake.GetSpaceConfigsStub != nil {
-		return fake.GetSpaceConfigsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSpaceConfigsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1865,15 +1888,16 @@ func (fake *FakeManager) GetSpaceDefaults() (*config.SpaceConfig, error) {
 	ret, specificReturn := fake.getSpaceDefaultsReturnsOnCall[len(fake.getSpaceDefaultsArgsForCall)]
 	fake.getSpaceDefaultsArgsForCall = append(fake.getSpaceDefaultsArgsForCall, struct {
 	}{})
+	stub := fake.GetSpaceDefaultsStub
+	fakeReturns := fake.getSpaceDefaultsReturns
 	fake.recordInvocation("GetSpaceDefaults", []interface{}{})
 	fake.getSpaceDefaultsMutex.Unlock()
-	if fake.GetSpaceDefaultsStub != nil {
-		return fake.GetSpaceDefaultsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSpaceDefaultsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1922,15 +1946,16 @@ func (fake *FakeManager) GetSpaceQuota(arg1 string, arg2 string) (*config.SpaceQ
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetSpaceQuotaStub
+	fakeReturns := fake.getSpaceQuotaReturns
 	fake.recordInvocation("GetSpaceQuota", []interface{}{arg1, arg2})
 	fake.getSpaceQuotaMutex.Unlock()
-	if fake.GetSpaceQuotaStub != nil {
-		return fake.GetSpaceQuotaStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSpaceQuotaReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1985,15 +2010,16 @@ func (fake *FakeManager) GetSpaceQuotas(arg1 string) ([]config.SpaceQuota, error
 	fake.getSpaceQuotasArgsForCall = append(fake.getSpaceQuotasArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetSpaceQuotasStub
+	fakeReturns := fake.getSpaceQuotasReturns
 	fake.recordInvocation("GetSpaceQuotas", []interface{}{arg1})
 	fake.getSpaceQuotasMutex.Unlock()
-	if fake.GetSpaceQuotasStub != nil {
-		return fake.GetSpaceQuotasStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSpaceQuotasReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2050,15 +2076,16 @@ func (fake *FakeManager) LdapConfig(arg1 string, arg2 string, arg3 string) (*con
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.LdapConfigStub
+	fakeReturns := fake.ldapConfigReturns
 	fake.recordInvocation("LdapConfig", []interface{}{arg1, arg2, arg3})
 	fake.ldapConfigMutex.Unlock()
-	if fake.LdapConfigStub != nil {
-		return fake.LdapConfigStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.ldapConfigReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2113,15 +2140,16 @@ func (fake *FakeManager) OrgSpaces(arg1 string) (*config.Spaces, error) {
 	fake.orgSpacesArgsForCall = append(fake.orgSpacesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.OrgSpacesStub
+	fakeReturns := fake.orgSpacesReturns
 	fake.recordInvocation("OrgSpaces", []interface{}{arg1})
 	fake.orgSpacesMutex.Unlock()
-	if fake.OrgSpacesStub != nil {
-		return fake.OrgSpacesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.orgSpacesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2175,15 +2203,16 @@ func (fake *FakeManager) Orgs() (*config.Orgs, error) {
 	ret, specificReturn := fake.orgsReturnsOnCall[len(fake.orgsArgsForCall)]
 	fake.orgsArgsForCall = append(fake.orgsArgsForCall, struct {
 	}{})
+	stub := fake.OrgsStub
+	fakeReturns := fake.orgsReturns
 	fake.recordInvocation("Orgs", []interface{}{})
 	fake.orgsMutex.Unlock()
-	if fake.OrgsStub != nil {
-		return fake.OrgsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.orgsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2231,15 +2260,16 @@ func (fake *FakeManager) RenameOrgConfig(arg1 *config.OrgConfig) error {
 	fake.renameOrgConfigArgsForCall = append(fake.renameOrgConfigArgsForCall, struct {
 		arg1 *config.OrgConfig
 	}{arg1})
+	stub := fake.RenameOrgConfigStub
+	fakeReturns := fake.renameOrgConfigReturns
 	fake.recordInvocation("RenameOrgConfig", []interface{}{arg1})
 	fake.renameOrgConfigMutex.Unlock()
-	if fake.RenameOrgConfigStub != nil {
-		return fake.RenameOrgConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.renameOrgConfigReturns
 	return fakeReturns.result1
 }
 
@@ -2291,15 +2321,16 @@ func (fake *FakeManager) RenameSpaceConfig(arg1 *config.SpaceConfig) error {
 	fake.renameSpaceConfigArgsForCall = append(fake.renameSpaceConfigArgsForCall, struct {
 		arg1 *config.SpaceConfig
 	}{arg1})
+	stub := fake.RenameSpaceConfigStub
+	fakeReturns := fake.renameSpaceConfigReturns
 	fake.recordInvocation("RenameSpaceConfig", []interface{}{arg1})
 	fake.renameSpaceConfigMutex.Unlock()
-	if fake.RenameSpaceConfigStub != nil {
-		return fake.RenameSpaceConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.renameSpaceConfigReturns
 	return fakeReturns.result1
 }
 
@@ -2351,15 +2382,16 @@ func (fake *FakeManager) SaveGlobalConfig(arg1 *config.GlobalConfig) error {
 	fake.saveGlobalConfigArgsForCall = append(fake.saveGlobalConfigArgsForCall, struct {
 		arg1 *config.GlobalConfig
 	}{arg1})
+	stub := fake.SaveGlobalConfigStub
+	fakeReturns := fake.saveGlobalConfigReturns
 	fake.recordInvocation("SaveGlobalConfig", []interface{}{arg1})
 	fake.saveGlobalConfigMutex.Unlock()
-	if fake.SaveGlobalConfigStub != nil {
-		return fake.SaveGlobalConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveGlobalConfigReturns
 	return fakeReturns.result1
 }
 
@@ -2411,15 +2443,16 @@ func (fake *FakeManager) SaveOrgConfig(arg1 *config.OrgConfig) error {
 	fake.saveOrgConfigArgsForCall = append(fake.saveOrgConfigArgsForCall, struct {
 		arg1 *config.OrgConfig
 	}{arg1})
+	stub := fake.SaveOrgConfigStub
+	fakeReturns := fake.saveOrgConfigReturns
 	fake.recordInvocation("SaveOrgConfig", []interface{}{arg1})
 	fake.saveOrgConfigMutex.Unlock()
-	if fake.SaveOrgConfigStub != nil {
-		return fake.SaveOrgConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveOrgConfigReturns
 	return fakeReturns.result1
 }
 
@@ -2471,15 +2504,16 @@ func (fake *FakeManager) SaveOrgQuota(arg1 *config.OrgQuota) error {
 	fake.saveOrgQuotaArgsForCall = append(fake.saveOrgQuotaArgsForCall, struct {
 		arg1 *config.OrgQuota
 	}{arg1})
+	stub := fake.SaveOrgQuotaStub
+	fakeReturns := fake.saveOrgQuotaReturns
 	fake.recordInvocation("SaveOrgQuota", []interface{}{arg1})
 	fake.saveOrgQuotaMutex.Unlock()
-	if fake.SaveOrgQuotaStub != nil {
-		return fake.SaveOrgQuotaStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveOrgQuotaReturns
 	return fakeReturns.result1
 }
 
@@ -2531,15 +2565,16 @@ func (fake *FakeManager) SaveOrgSpaces(arg1 *config.Spaces) error {
 	fake.saveOrgSpacesArgsForCall = append(fake.saveOrgSpacesArgsForCall, struct {
 		arg1 *config.Spaces
 	}{arg1})
+	stub := fake.SaveOrgSpacesStub
+	fakeReturns := fake.saveOrgSpacesReturns
 	fake.recordInvocation("SaveOrgSpaces", []interface{}{arg1})
 	fake.saveOrgSpacesMutex.Unlock()
-	if fake.SaveOrgSpacesStub != nil {
-		return fake.SaveOrgSpacesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveOrgSpacesReturns
 	return fakeReturns.result1
 }
 
@@ -2591,15 +2626,16 @@ func (fake *FakeManager) SaveOrgs(arg1 *config.Orgs) error {
 	fake.saveOrgsArgsForCall = append(fake.saveOrgsArgsForCall, struct {
 		arg1 *config.Orgs
 	}{arg1})
+	stub := fake.SaveOrgsStub
+	fakeReturns := fake.saveOrgsReturns
 	fake.recordInvocation("SaveOrgs", []interface{}{arg1})
 	fake.saveOrgsMutex.Unlock()
-	if fake.SaveOrgsStub != nil {
-		return fake.SaveOrgsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveOrgsReturns
 	return fakeReturns.result1
 }
 
@@ -2651,15 +2687,16 @@ func (fake *FakeManager) SaveSpaceConfig(arg1 *config.SpaceConfig) error {
 	fake.saveSpaceConfigArgsForCall = append(fake.saveSpaceConfigArgsForCall, struct {
 		arg1 *config.SpaceConfig
 	}{arg1})
+	stub := fake.SaveSpaceConfigStub
+	fakeReturns := fake.saveSpaceConfigReturns
 	fake.recordInvocation("SaveSpaceConfig", []interface{}{arg1})
 	fake.saveSpaceConfigMutex.Unlock()
-	if fake.SaveSpaceConfigStub != nil {
-		return fake.SaveSpaceConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveSpaceConfigReturns
 	return fakeReturns.result1
 }
 
@@ -2711,15 +2748,16 @@ func (fake *FakeManager) SaveSpaceQuota(arg1 *config.SpaceQuota) error {
 	fake.saveSpaceQuotaArgsForCall = append(fake.saveSpaceQuotaArgsForCall, struct {
 		arg1 *config.SpaceQuota
 	}{arg1})
+	stub := fake.SaveSpaceQuotaStub
+	fakeReturns := fake.saveSpaceQuotaReturns
 	fake.recordInvocation("SaveSpaceQuota", []interface{}{arg1})
 	fake.saveSpaceQuotaMutex.Unlock()
-	if fake.SaveSpaceQuotaStub != nil {
-		return fake.SaveSpaceQuotaStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveSpaceQuotaReturns
 	return fakeReturns.result1
 }
 
@@ -2770,15 +2808,16 @@ func (fake *FakeManager) Spaces() ([]config.Spaces, error) {
 	ret, specificReturn := fake.spacesReturnsOnCall[len(fake.spacesArgsForCall)]
 	fake.spacesArgsForCall = append(fake.spacesArgsForCall, struct {
 	}{})
+	stub := fake.SpacesStub
+	fakeReturns := fake.spacesReturns
 	fake.recordInvocation("Spaces", []interface{}{})
 	fake.spacesMutex.Unlock()
-	if fake.SpacesStub != nil {
-		return fake.SpacesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.spacesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/config/fakes/fake_reader.go
+++ b/config/fakes/fake_reader.go
@@ -220,15 +220,16 @@ func (fake *FakeReader) GetASGConfigs() ([]config.ASGConfig, error) {
 	ret, specificReturn := fake.getASGConfigsReturnsOnCall[len(fake.getASGConfigsArgsForCall)]
 	fake.getASGConfigsArgsForCall = append(fake.getASGConfigsArgsForCall, struct {
 	}{})
+	stub := fake.GetASGConfigsStub
+	fakeReturns := fake.getASGConfigsReturns
 	fake.recordInvocation("GetASGConfigs", []interface{}{})
 	fake.getASGConfigsMutex.Unlock()
-	if fake.GetASGConfigsStub != nil {
-		return fake.GetASGConfigsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getASGConfigsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -275,15 +276,16 @@ func (fake *FakeReader) GetDefaultASGConfigs() ([]config.ASGConfig, error) {
 	ret, specificReturn := fake.getDefaultASGConfigsReturnsOnCall[len(fake.getDefaultASGConfigsArgsForCall)]
 	fake.getDefaultASGConfigsArgsForCall = append(fake.getDefaultASGConfigsArgsForCall, struct {
 	}{})
+	stub := fake.GetDefaultASGConfigsStub
+	fakeReturns := fake.getDefaultASGConfigsReturns
 	fake.recordInvocation("GetDefaultASGConfigs", []interface{}{})
 	fake.getDefaultASGConfigsMutex.Unlock()
-	if fake.GetDefaultASGConfigsStub != nil {
-		return fake.GetDefaultASGConfigsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getDefaultASGConfigsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -330,15 +332,16 @@ func (fake *FakeReader) GetGlobalConfig() (*config.GlobalConfig, error) {
 	ret, specificReturn := fake.getGlobalConfigReturnsOnCall[len(fake.getGlobalConfigArgsForCall)]
 	fake.getGlobalConfigArgsForCall = append(fake.getGlobalConfigArgsForCall, struct {
 	}{})
+	stub := fake.GetGlobalConfigStub
+	fakeReturns := fake.getGlobalConfigReturns
 	fake.recordInvocation("GetGlobalConfig", []interface{}{})
 	fake.getGlobalConfigMutex.Unlock()
-	if fake.GetGlobalConfigStub != nil {
-		return fake.GetGlobalConfigStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getGlobalConfigReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -386,15 +389,16 @@ func (fake *FakeReader) GetOrgConfig(arg1 string) (*config.OrgConfig, error) {
 	fake.getOrgConfigArgsForCall = append(fake.getOrgConfigArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetOrgConfigStub
+	fakeReturns := fake.getOrgConfigReturns
 	fake.recordInvocation("GetOrgConfig", []interface{}{arg1})
 	fake.getOrgConfigMutex.Unlock()
-	if fake.GetOrgConfigStub != nil {
-		return fake.GetOrgConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getOrgConfigReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -448,15 +452,16 @@ func (fake *FakeReader) GetOrgConfigs() ([]config.OrgConfig, error) {
 	ret, specificReturn := fake.getOrgConfigsReturnsOnCall[len(fake.getOrgConfigsArgsForCall)]
 	fake.getOrgConfigsArgsForCall = append(fake.getOrgConfigsArgsForCall, struct {
 	}{})
+	stub := fake.GetOrgConfigsStub
+	fakeReturns := fake.getOrgConfigsReturns
 	fake.recordInvocation("GetOrgConfigs", []interface{}{})
 	fake.getOrgConfigsMutex.Unlock()
-	if fake.GetOrgConfigsStub != nil {
-		return fake.GetOrgConfigsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getOrgConfigsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -504,15 +509,16 @@ func (fake *FakeReader) GetOrgQuota(arg1 string) (*config.OrgQuota, error) {
 	fake.getOrgQuotaArgsForCall = append(fake.getOrgQuotaArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetOrgQuotaStub
+	fakeReturns := fake.getOrgQuotaReturns
 	fake.recordInvocation("GetOrgQuota", []interface{}{arg1})
 	fake.getOrgQuotaMutex.Unlock()
-	if fake.GetOrgQuotaStub != nil {
-		return fake.GetOrgQuotaStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getOrgQuotaReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -566,15 +572,16 @@ func (fake *FakeReader) GetOrgQuotas() ([]config.OrgQuota, error) {
 	ret, specificReturn := fake.getOrgQuotasReturnsOnCall[len(fake.getOrgQuotasArgsForCall)]
 	fake.getOrgQuotasArgsForCall = append(fake.getOrgQuotasArgsForCall, struct {
 	}{})
+	stub := fake.GetOrgQuotasStub
+	fakeReturns := fake.getOrgQuotasReturns
 	fake.recordInvocation("GetOrgQuotas", []interface{}{})
 	fake.getOrgQuotasMutex.Unlock()
-	if fake.GetOrgQuotasStub != nil {
-		return fake.GetOrgQuotasStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getOrgQuotasReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -623,15 +630,16 @@ func (fake *FakeReader) GetSpaceConfig(arg1 string, arg2 string) (*config.SpaceC
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetSpaceConfigStub
+	fakeReturns := fake.getSpaceConfigReturns
 	fake.recordInvocation("GetSpaceConfig", []interface{}{arg1, arg2})
 	fake.getSpaceConfigMutex.Unlock()
-	if fake.GetSpaceConfigStub != nil {
-		return fake.GetSpaceConfigStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSpaceConfigReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -685,15 +693,16 @@ func (fake *FakeReader) GetSpaceConfigs() ([]config.SpaceConfig, error) {
 	ret, specificReturn := fake.getSpaceConfigsReturnsOnCall[len(fake.getSpaceConfigsArgsForCall)]
 	fake.getSpaceConfigsArgsForCall = append(fake.getSpaceConfigsArgsForCall, struct {
 	}{})
+	stub := fake.GetSpaceConfigsStub
+	fakeReturns := fake.getSpaceConfigsReturns
 	fake.recordInvocation("GetSpaceConfigs", []interface{}{})
 	fake.getSpaceConfigsMutex.Unlock()
-	if fake.GetSpaceConfigsStub != nil {
-		return fake.GetSpaceConfigsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSpaceConfigsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -740,15 +749,16 @@ func (fake *FakeReader) GetSpaceDefaults() (*config.SpaceConfig, error) {
 	ret, specificReturn := fake.getSpaceDefaultsReturnsOnCall[len(fake.getSpaceDefaultsArgsForCall)]
 	fake.getSpaceDefaultsArgsForCall = append(fake.getSpaceDefaultsArgsForCall, struct {
 	}{})
+	stub := fake.GetSpaceDefaultsStub
+	fakeReturns := fake.getSpaceDefaultsReturns
 	fake.recordInvocation("GetSpaceDefaults", []interface{}{})
 	fake.getSpaceDefaultsMutex.Unlock()
-	if fake.GetSpaceDefaultsStub != nil {
-		return fake.GetSpaceDefaultsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSpaceDefaultsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -797,15 +807,16 @@ func (fake *FakeReader) GetSpaceQuota(arg1 string, arg2 string) (*config.SpaceQu
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetSpaceQuotaStub
+	fakeReturns := fake.getSpaceQuotaReturns
 	fake.recordInvocation("GetSpaceQuota", []interface{}{arg1, arg2})
 	fake.getSpaceQuotaMutex.Unlock()
-	if fake.GetSpaceQuotaStub != nil {
-		return fake.GetSpaceQuotaStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSpaceQuotaReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -860,15 +871,16 @@ func (fake *FakeReader) GetSpaceQuotas(arg1 string) ([]config.SpaceQuota, error)
 	fake.getSpaceQuotasArgsForCall = append(fake.getSpaceQuotasArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetSpaceQuotasStub
+	fakeReturns := fake.getSpaceQuotasReturns
 	fake.recordInvocation("GetSpaceQuotas", []interface{}{arg1})
 	fake.getSpaceQuotasMutex.Unlock()
-	if fake.GetSpaceQuotasStub != nil {
-		return fake.GetSpaceQuotasStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSpaceQuotasReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -925,15 +937,16 @@ func (fake *FakeReader) LdapConfig(arg1 string, arg2 string, arg3 string) (*conf
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.LdapConfigStub
+	fakeReturns := fake.ldapConfigReturns
 	fake.recordInvocation("LdapConfig", []interface{}{arg1, arg2, arg3})
 	fake.ldapConfigMutex.Unlock()
-	if fake.LdapConfigStub != nil {
-		return fake.LdapConfigStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.ldapConfigReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -988,15 +1001,16 @@ func (fake *FakeReader) OrgSpaces(arg1 string) (*config.Spaces, error) {
 	fake.orgSpacesArgsForCall = append(fake.orgSpacesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.OrgSpacesStub
+	fakeReturns := fake.orgSpacesReturns
 	fake.recordInvocation("OrgSpaces", []interface{}{arg1})
 	fake.orgSpacesMutex.Unlock()
-	if fake.OrgSpacesStub != nil {
-		return fake.OrgSpacesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.orgSpacesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1050,15 +1064,16 @@ func (fake *FakeReader) Orgs() (*config.Orgs, error) {
 	ret, specificReturn := fake.orgsReturnsOnCall[len(fake.orgsArgsForCall)]
 	fake.orgsArgsForCall = append(fake.orgsArgsForCall, struct {
 	}{})
+	stub := fake.OrgsStub
+	fakeReturns := fake.orgsReturns
 	fake.recordInvocation("Orgs", []interface{}{})
 	fake.orgsMutex.Unlock()
-	if fake.OrgsStub != nil {
-		return fake.OrgsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.orgsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1105,15 +1120,16 @@ func (fake *FakeReader) Spaces() ([]config.Spaces, error) {
 	ret, specificReturn := fake.spacesReturnsOnCall[len(fake.spacesArgsForCall)]
 	fake.spacesArgsForCall = append(fake.spacesArgsForCall, struct {
 	}{})
+	stub := fake.SpacesStub
+	fakeReturns := fake.spacesReturns
 	fake.recordInvocation("Spaces", []interface{}{})
 	fake.spacesMutex.Unlock()
-	if fake.SpacesStub != nil {
-		return fake.SpacesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.spacesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/config/fakes/fake_updater.go
+++ b/config/fakes/fake_updater.go
@@ -289,15 +289,16 @@ func (fake *FakeUpdater) AddDefaultSecurityGroup(arg1 string, arg2 []byte) error
 		arg1 string
 		arg2 []byte
 	}{arg1, arg2Copy})
+	stub := fake.AddDefaultSecurityGroupStub
+	fakeReturns := fake.addDefaultSecurityGroupReturns
 	fake.recordInvocation("AddDefaultSecurityGroup", []interface{}{arg1, arg2Copy})
 	fake.addDefaultSecurityGroupMutex.Unlock()
-	if fake.AddDefaultSecurityGroupStub != nil {
-		return fake.AddDefaultSecurityGroupStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addDefaultSecurityGroupReturns
 	return fakeReturns.result1
 }
 
@@ -349,15 +350,16 @@ func (fake *FakeUpdater) AddOrgQuota(arg1 config.OrgQuota) error {
 	fake.addOrgQuotaArgsForCall = append(fake.addOrgQuotaArgsForCall, struct {
 		arg1 config.OrgQuota
 	}{arg1})
+	stub := fake.AddOrgQuotaStub
+	fakeReturns := fake.addOrgQuotaReturns
 	fake.recordInvocation("AddOrgQuota", []interface{}{arg1})
 	fake.addOrgQuotaMutex.Unlock()
-	if fake.AddOrgQuotaStub != nil {
-		return fake.AddOrgQuotaStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addOrgQuotaReturns
 	return fakeReturns.result1
 }
 
@@ -409,15 +411,16 @@ func (fake *FakeUpdater) AddOrgToConfig(arg1 *config.OrgConfig) error {
 	fake.addOrgToConfigArgsForCall = append(fake.addOrgToConfigArgsForCall, struct {
 		arg1 *config.OrgConfig
 	}{arg1})
+	stub := fake.AddOrgToConfigStub
+	fakeReturns := fake.addOrgToConfigReturns
 	fake.recordInvocation("AddOrgToConfig", []interface{}{arg1})
 	fake.addOrgToConfigMutex.Unlock()
-	if fake.AddOrgToConfigStub != nil {
-		return fake.AddOrgToConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addOrgToConfigReturns
 	return fakeReturns.result1
 }
 
@@ -475,15 +478,16 @@ func (fake *FakeUpdater) AddSecurityGroup(arg1 string, arg2 []byte) error {
 		arg1 string
 		arg2 []byte
 	}{arg1, arg2Copy})
+	stub := fake.AddSecurityGroupStub
+	fakeReturns := fake.addSecurityGroupReturns
 	fake.recordInvocation("AddSecurityGroup", []interface{}{arg1, arg2Copy})
 	fake.addSecurityGroupMutex.Unlock()
-	if fake.AddSecurityGroupStub != nil {
-		return fake.AddSecurityGroupStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addSecurityGroupReturns
 	return fakeReturns.result1
 }
 
@@ -542,15 +546,16 @@ func (fake *FakeUpdater) AddSecurityGroupToSpace(arg1 string, arg2 string, arg3 
 		arg2 string
 		arg3 []byte
 	}{arg1, arg2, arg3Copy})
+	stub := fake.AddSecurityGroupToSpaceStub
+	fakeReturns := fake.addSecurityGroupToSpaceReturns
 	fake.recordInvocation("AddSecurityGroupToSpace", []interface{}{arg1, arg2, arg3Copy})
 	fake.addSecurityGroupToSpaceMutex.Unlock()
-	if fake.AddSecurityGroupToSpaceStub != nil {
-		return fake.AddSecurityGroupToSpaceStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addSecurityGroupToSpaceReturns
 	return fakeReturns.result1
 }
 
@@ -602,15 +607,16 @@ func (fake *FakeUpdater) AddSpaceQuota(arg1 config.SpaceQuota) error {
 	fake.addSpaceQuotaArgsForCall = append(fake.addSpaceQuotaArgsForCall, struct {
 		arg1 config.SpaceQuota
 	}{arg1})
+	stub := fake.AddSpaceQuotaStub
+	fakeReturns := fake.addSpaceQuotaReturns
 	fake.recordInvocation("AddSpaceQuota", []interface{}{arg1})
 	fake.addSpaceQuotaMutex.Unlock()
-	if fake.AddSpaceQuotaStub != nil {
-		return fake.AddSpaceQuotaStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addSpaceQuotaReturns
 	return fakeReturns.result1
 }
 
@@ -662,15 +668,16 @@ func (fake *FakeUpdater) AddSpaceToConfig(arg1 *config.SpaceConfig) error {
 	fake.addSpaceToConfigArgsForCall = append(fake.addSpaceToConfigArgsForCall, struct {
 		arg1 *config.SpaceConfig
 	}{arg1})
+	stub := fake.AddSpaceToConfigStub
+	fakeReturns := fake.addSpaceToConfigReturns
 	fake.recordInvocation("AddSpaceToConfig", []interface{}{arg1})
 	fake.addSpaceToConfigMutex.Unlock()
-	if fake.AddSpaceToConfigStub != nil {
-		return fake.AddSpaceToConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addSpaceToConfigReturns
 	return fakeReturns.result1
 }
 
@@ -724,15 +731,16 @@ func (fake *FakeUpdater) AssociateOrgAuditor(arg1 config.UserOrigin, arg2 string
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.AssociateOrgAuditorStub
+	fakeReturns := fake.associateOrgAuditorReturns
 	fake.recordInvocation("AssociateOrgAuditor", []interface{}{arg1, arg2, arg3})
 	fake.associateOrgAuditorMutex.Unlock()
-	if fake.AssociateOrgAuditorStub != nil {
-		return fake.AssociateOrgAuditorStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.associateOrgAuditorReturns
 	return fakeReturns.result1
 }
 
@@ -787,15 +795,16 @@ func (fake *FakeUpdater) AssociateSpaceAuditor(arg1 config.UserOrigin, arg2 stri
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.AssociateSpaceAuditorStub
+	fakeReturns := fake.associateSpaceAuditorReturns
 	fake.recordInvocation("AssociateSpaceAuditor", []interface{}{arg1, arg2, arg3, arg4})
 	fake.associateSpaceAuditorMutex.Unlock()
-	if fake.AssociateSpaceAuditorStub != nil {
-		return fake.AssociateSpaceAuditorStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.associateSpaceAuditorReturns
 	return fakeReturns.result1
 }
 
@@ -850,15 +859,16 @@ func (fake *FakeUpdater) AssociateSpaceDeveloper(arg1 config.UserOrigin, arg2 st
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.AssociateSpaceDeveloperStub
+	fakeReturns := fake.associateSpaceDeveloperReturns
 	fake.recordInvocation("AssociateSpaceDeveloper", []interface{}{arg1, arg2, arg3, arg4})
 	fake.associateSpaceDeveloperMutex.Unlock()
-	if fake.AssociateSpaceDeveloperStub != nil {
-		return fake.AssociateSpaceDeveloperStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.associateSpaceDeveloperReturns
 	return fakeReturns.result1
 }
 
@@ -910,15 +920,16 @@ func (fake *FakeUpdater) CreateConfigIfNotExists(arg1 string) error {
 	fake.createConfigIfNotExistsArgsForCall = append(fake.createConfigIfNotExistsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.CreateConfigIfNotExistsStub
+	fakeReturns := fake.createConfigIfNotExistsReturns
 	fake.recordInvocation("CreateConfigIfNotExists", []interface{}{arg1})
 	fake.createConfigIfNotExistsMutex.Unlock()
-	if fake.CreateConfigIfNotExistsStub != nil {
-		return fake.CreateConfigIfNotExistsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createConfigIfNotExistsReturns
 	return fakeReturns.result1
 }
 
@@ -969,15 +980,16 @@ func (fake *FakeUpdater) DeleteConfigIfExists() error {
 	ret, specificReturn := fake.deleteConfigIfExistsReturnsOnCall[len(fake.deleteConfigIfExistsArgsForCall)]
 	fake.deleteConfigIfExistsArgsForCall = append(fake.deleteConfigIfExistsArgsForCall, struct {
 	}{})
+	stub := fake.DeleteConfigIfExistsStub
+	fakeReturns := fake.deleteConfigIfExistsReturns
 	fake.recordInvocation("DeleteConfigIfExists", []interface{}{})
 	fake.deleteConfigIfExistsMutex.Unlock()
-	if fake.DeleteConfigIfExistsStub != nil {
-		return fake.DeleteConfigIfExistsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteConfigIfExistsReturns
 	return fakeReturns.result1
 }
 
@@ -1022,15 +1034,16 @@ func (fake *FakeUpdater) DeleteOrgConfig(arg1 string) error {
 	fake.deleteOrgConfigArgsForCall = append(fake.deleteOrgConfigArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.DeleteOrgConfigStub
+	fakeReturns := fake.deleteOrgConfigReturns
 	fake.recordInvocation("DeleteOrgConfig", []interface{}{arg1})
 	fake.deleteOrgConfigMutex.Unlock()
-	if fake.DeleteOrgConfigStub != nil {
-		return fake.DeleteOrgConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteOrgConfigReturns
 	return fakeReturns.result1
 }
 
@@ -1083,15 +1096,16 @@ func (fake *FakeUpdater) DeleteSpaceConfig(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.DeleteSpaceConfigStub
+	fakeReturns := fake.deleteSpaceConfigReturns
 	fake.recordInvocation("DeleteSpaceConfig", []interface{}{arg1, arg2})
 	fake.deleteSpaceConfigMutex.Unlock()
-	if fake.DeleteSpaceConfigStub != nil {
-		return fake.DeleteSpaceConfigStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteSpaceConfigReturns
 	return fakeReturns.result1
 }
 
@@ -1143,15 +1157,16 @@ func (fake *FakeUpdater) RenameOrgConfig(arg1 *config.OrgConfig) error {
 	fake.renameOrgConfigArgsForCall = append(fake.renameOrgConfigArgsForCall, struct {
 		arg1 *config.OrgConfig
 	}{arg1})
+	stub := fake.RenameOrgConfigStub
+	fakeReturns := fake.renameOrgConfigReturns
 	fake.recordInvocation("RenameOrgConfig", []interface{}{arg1})
 	fake.renameOrgConfigMutex.Unlock()
-	if fake.RenameOrgConfigStub != nil {
-		return fake.RenameOrgConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.renameOrgConfigReturns
 	return fakeReturns.result1
 }
 
@@ -1203,15 +1218,16 @@ func (fake *FakeUpdater) RenameSpaceConfig(arg1 *config.SpaceConfig) error {
 	fake.renameSpaceConfigArgsForCall = append(fake.renameSpaceConfigArgsForCall, struct {
 		arg1 *config.SpaceConfig
 	}{arg1})
+	stub := fake.RenameSpaceConfigStub
+	fakeReturns := fake.renameSpaceConfigReturns
 	fake.recordInvocation("RenameSpaceConfig", []interface{}{arg1})
 	fake.renameSpaceConfigMutex.Unlock()
-	if fake.RenameSpaceConfigStub != nil {
-		return fake.RenameSpaceConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.renameSpaceConfigReturns
 	return fakeReturns.result1
 }
 
@@ -1263,15 +1279,16 @@ func (fake *FakeUpdater) SaveGlobalConfig(arg1 *config.GlobalConfig) error {
 	fake.saveGlobalConfigArgsForCall = append(fake.saveGlobalConfigArgsForCall, struct {
 		arg1 *config.GlobalConfig
 	}{arg1})
+	stub := fake.SaveGlobalConfigStub
+	fakeReturns := fake.saveGlobalConfigReturns
 	fake.recordInvocation("SaveGlobalConfig", []interface{}{arg1})
 	fake.saveGlobalConfigMutex.Unlock()
-	if fake.SaveGlobalConfigStub != nil {
-		return fake.SaveGlobalConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveGlobalConfigReturns
 	return fakeReturns.result1
 }
 
@@ -1323,15 +1340,16 @@ func (fake *FakeUpdater) SaveOrgConfig(arg1 *config.OrgConfig) error {
 	fake.saveOrgConfigArgsForCall = append(fake.saveOrgConfigArgsForCall, struct {
 		arg1 *config.OrgConfig
 	}{arg1})
+	stub := fake.SaveOrgConfigStub
+	fakeReturns := fake.saveOrgConfigReturns
 	fake.recordInvocation("SaveOrgConfig", []interface{}{arg1})
 	fake.saveOrgConfigMutex.Unlock()
-	if fake.SaveOrgConfigStub != nil {
-		return fake.SaveOrgConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveOrgConfigReturns
 	return fakeReturns.result1
 }
 
@@ -1383,15 +1401,16 @@ func (fake *FakeUpdater) SaveOrgQuota(arg1 *config.OrgQuota) error {
 	fake.saveOrgQuotaArgsForCall = append(fake.saveOrgQuotaArgsForCall, struct {
 		arg1 *config.OrgQuota
 	}{arg1})
+	stub := fake.SaveOrgQuotaStub
+	fakeReturns := fake.saveOrgQuotaReturns
 	fake.recordInvocation("SaveOrgQuota", []interface{}{arg1})
 	fake.saveOrgQuotaMutex.Unlock()
-	if fake.SaveOrgQuotaStub != nil {
-		return fake.SaveOrgQuotaStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveOrgQuotaReturns
 	return fakeReturns.result1
 }
 
@@ -1443,15 +1462,16 @@ func (fake *FakeUpdater) SaveOrgSpaces(arg1 *config.Spaces) error {
 	fake.saveOrgSpacesArgsForCall = append(fake.saveOrgSpacesArgsForCall, struct {
 		arg1 *config.Spaces
 	}{arg1})
+	stub := fake.SaveOrgSpacesStub
+	fakeReturns := fake.saveOrgSpacesReturns
 	fake.recordInvocation("SaveOrgSpaces", []interface{}{arg1})
 	fake.saveOrgSpacesMutex.Unlock()
-	if fake.SaveOrgSpacesStub != nil {
-		return fake.SaveOrgSpacesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveOrgSpacesReturns
 	return fakeReturns.result1
 }
 
@@ -1503,15 +1523,16 @@ func (fake *FakeUpdater) SaveOrgs(arg1 *config.Orgs) error {
 	fake.saveOrgsArgsForCall = append(fake.saveOrgsArgsForCall, struct {
 		arg1 *config.Orgs
 	}{arg1})
+	stub := fake.SaveOrgsStub
+	fakeReturns := fake.saveOrgsReturns
 	fake.recordInvocation("SaveOrgs", []interface{}{arg1})
 	fake.saveOrgsMutex.Unlock()
-	if fake.SaveOrgsStub != nil {
-		return fake.SaveOrgsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveOrgsReturns
 	return fakeReturns.result1
 }
 
@@ -1563,15 +1584,16 @@ func (fake *FakeUpdater) SaveSpaceConfig(arg1 *config.SpaceConfig) error {
 	fake.saveSpaceConfigArgsForCall = append(fake.saveSpaceConfigArgsForCall, struct {
 		arg1 *config.SpaceConfig
 	}{arg1})
+	stub := fake.SaveSpaceConfigStub
+	fakeReturns := fake.saveSpaceConfigReturns
 	fake.recordInvocation("SaveSpaceConfig", []interface{}{arg1})
 	fake.saveSpaceConfigMutex.Unlock()
-	if fake.SaveSpaceConfigStub != nil {
-		return fake.SaveSpaceConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveSpaceConfigReturns
 	return fakeReturns.result1
 }
 
@@ -1623,15 +1645,16 @@ func (fake *FakeUpdater) SaveSpaceQuota(arg1 *config.SpaceQuota) error {
 	fake.saveSpaceQuotaArgsForCall = append(fake.saveSpaceQuotaArgsForCall, struct {
 		arg1 *config.SpaceQuota
 	}{arg1})
+	stub := fake.SaveSpaceQuotaStub
+	fakeReturns := fake.saveSpaceQuotaReturns
 	fake.recordInvocation("SaveSpaceQuota", []interface{}{arg1})
 	fake.saveSpaceQuotaMutex.Unlock()
-	if fake.SaveSpaceQuotaStub != nil {
-		return fake.SaveSpaceQuotaStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveSpaceQuotaReturns
 	return fakeReturns.result1
 }
 

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -84,13 +84,10 @@ func (m *yamlManager) GetASGConfigs() ([]ASGConfig, error) {
 	return result, nil
 }
 
-// GetIsolationSegmentConfig reads isolation segment config
+// GetGlobalConfig reads the global cf-mgmt.yml config
 func (m *yamlManager) GetGlobalConfig() (*GlobalConfig, error) {
 	globalConfig := &GlobalConfig{}
 	LoadFile(path.Join(m.ConfigDir, "cf-mgmt.yml"), globalConfig)
-	if len(globalConfig.MetadataPrefix) == 0 {
-		globalConfig.MetadataPrefix = "cf-mgmt.pivotal.io"
-	}
 	return globalConfig, nil
 }
 

--- a/configcommands/global_test.go
+++ b/configcommands/global_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Global", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				globalConfig, err := configManager.GetGlobalConfig()
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(globalConfig.MetadataPrefix).To(Equal("cf-mgmt.pivotal.io"))
+				Expect(globalConfig.MetadataPrefix).To(Equal(""))
 			})
 			It("Should be changed", func() {
 				command.MetadataPrefix = "foo.bar"

--- a/export/exportconfig.go
+++ b/export/exportconfig.go
@@ -409,6 +409,18 @@ func (im *Manager) processSpaces(orgConfig *config.OrgConfig, orgGUID string, ex
 			spaceConfig.AllowSSH = true
 		}
 
+		spaceMetadata, err := im.SpaceManager.GetSpaceMetadata(orgSpace.Guid)
+		if err != nil {
+			return err
+		}
+		if spaceMetadata != nil {
+			spaceConfig.Metadata = &config.Metadata{}
+			spaceConfig.Metadata.Labels = make(map[string]string)
+			for k, v := range spaceMetadata.Labels {
+				spaceConfig.Metadata.Labels[k] = v.(string)
+			}
+		}
+
 		spaceSGName := fmt.Sprintf("%s-%s", orgConfig.Org, spaceName)
 		if spaceSGNames, err := im.SecurityGroupManager.ListSpaceSecurityGroups(orgSpace.Guid); err == nil {
 			for securityGroupName, _ := range spaceSGNames {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fe68d7656a934f97e00eccd10c107c80276d82e1e30bb4d1719766a104d559a7
-updated: 2020-03-25T14:28:35.12063923-04:00
+hash: 4cb8fb89a954450bda2da179ce981a3d979e6417c3e591b6d25760f868c488d2
+updated: 2021-05-12T11:01:22.025991-07:00
 imports:
 - name: code.cloudfoundry.org/cfhttp
   version: fec6281a6f14dd04834fc71023411d4a5319bc12
@@ -18,14 +18,13 @@ imports:
 - name: github.com/bmizerany/pat
   version: 6226ea591a40176dd3ff9cd8eff81ed6ca721a00
 - name: github.com/cloudfoundry-community/go-cfclient
-  version: 3c43ef9aebb6d79f57ce24c5c0f087cadc558aa1
-  repo: https://github.com/calebwashburn/go-cfclient
+  version: 346e7b24e1309b2decfb347863aec7fb3b77319b
 - name: github.com/cloudfoundry-community/go-uaa
-  version: 673d775e96b5d67f107a28c169384df45dd9d0ac
+  version: 7af3c2d91d5edb96720cc0532cd9e0c805ee8cea
   subpackages:
   - passwordcredentials
 - name: github.com/fatih/color
-  version: daf2830f2741ebb735b21709a520c5f37d642d85
+  version: bc2269661d49c6c9d0e514eef49710556883f3fa
 - name: github.com/go-asn1-ber/asn1-ber
   version: effdc98edfb5dde0d9fd8dfba266f6483e6ce9f0
 - name: github.com/go-ldap/ldap
@@ -61,7 +60,7 @@ imports:
   - html/atom
   - html/charset
 - name: golang.org/x/oauth2
-  version: bf48bf16ab8d622ce64ec6ce98d2c98f916b6303
+  version: 81ed05c6b58c5509b83ac75450e38d97242e7168
   subpackages:
   - clientcredentials
   - internal
@@ -78,24 +77,28 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53403b58ad1b561927d19068c655246f2db79d48
 testImports:
-- name: github.com/hpcloud/tail
-  version: a1dbeea552b7c8df4b542c66073e393de198a800
+- name: github.com/fsnotify/fsnotify
+  version: 7f4cf4dd2b522a984eaca51d1ccee54101d3414a
+- name: github.com/maxbrunsfeld/counterfeiter
+  version: a447b6683e1c8c0cf34464d3024d39dcaa1237b7
+- name: github.com/moul/http2curl
+  version: 9280a7ca1854f93dfee71d5e7d448627123efaf5
+- name: github.com/nxadm/tail
+  version: 92547340f0cc8aa12fbbb6dc2ec776190b0923ca
   subpackages:
   - ratelimiter
   - util
   - watch
   - winfile
-- name: github.com/maxbrunsfeld/counterfeiter
-  version: a447b6683e1c8c0cf34464d3024d39dcaa1237b7
-- name: github.com/moul/http2curl
-  version: 9280a7ca1854f93dfee71d5e7d448627123efaf5
 - name: github.com/onsi/ginkgo
-  version: 40598150331533e3cd497f21dcce387dae84b561
+  version: 084bfa8b8d831128c05e1640aed57b017c7a26a7
   subpackages:
   - config
+  - formatter
   - internal/codelocation
   - internal/containernode
   - internal/failer
+  - internal/global
   - internal/leafnodes
   - internal/remote
   - internal/spec
@@ -110,7 +113,7 @@ testImports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: 6be6c439588487cd908a3a700795660c2a16dfec
+  version: b001323982e2f4cdf9d868ee8d91160027c35f47
   subpackages:
   - format
   - gbytes
@@ -149,11 +152,5 @@ testImports:
   - language
   - runes
   - transform
-- name: golang.org/x/xerrors
-  version: 9bdfabe68543c54f90421aeb9a60ef8061b5b544
-  subpackages:
-  - internal
-- name: gopkg.in/fsnotify/fsnotify.v1
-  version: 45d7d09e39ef4ac08d493309fa031790c15bfe8a
 - name: gopkg.in/tomb.v1
   version: c131134a1947e9afd9cecfe11f4c6dff0732ae58

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,16 +6,11 @@ import:
 - package: github.com/jessevdk/go-flags
   version: ~1.3.0
 - package: github.com/cloudfoundry-community/go-cfclient
-  version: 3c43ef9aebb6d79f57ce24c5c0f087cadc558aa1
-  repo: https://github.com/calebwashburn/go-cfclient
 - package: golang.org/x/oauth2
-  version: master
 - package: github.com/pkg/errors
   version: ~0.8.0
 - package: github.com/cloudfoundry-community/go-uaa
-  version: master
 - package: code.cloudfoundry.org/routing-api
-  version: master
 - package: github.com/fatih/color
   version: ^1.9.0
 testImport:

--- a/isosegment/fakes/fake_cf_client.go
+++ b/isosegment/fakes/fake_cf_client.go
@@ -177,15 +177,16 @@ func (fake *FakeCFClient) AddIsolationSegmentToOrg(arg1 string, arg2 string) err
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.AddIsolationSegmentToOrgStub
+	fakeReturns := fake.addIsolationSegmentToOrgReturns
 	fake.recordInvocation("AddIsolationSegmentToOrg", []interface{}{arg1, arg2})
 	fake.addIsolationSegmentToOrgMutex.Unlock()
-	if fake.AddIsolationSegmentToOrgStub != nil {
-		return fake.AddIsolationSegmentToOrgStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addIsolationSegmentToOrgReturns
 	return fakeReturns.result1
 }
 
@@ -238,15 +239,16 @@ func (fake *FakeCFClient) AddIsolationSegmentToSpace(arg1 string, arg2 string) e
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.AddIsolationSegmentToSpaceStub
+	fakeReturns := fake.addIsolationSegmentToSpaceReturns
 	fake.recordInvocation("AddIsolationSegmentToSpace", []interface{}{arg1, arg2})
 	fake.addIsolationSegmentToSpaceMutex.Unlock()
-	if fake.AddIsolationSegmentToSpaceStub != nil {
-		return fake.AddIsolationSegmentToSpaceStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addIsolationSegmentToSpaceReturns
 	return fakeReturns.result1
 }
 
@@ -298,15 +300,16 @@ func (fake *FakeCFClient) CreateIsolationSegment(arg1 string) (*cfclient.Isolati
 	fake.createIsolationSegmentArgsForCall = append(fake.createIsolationSegmentArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.CreateIsolationSegmentStub
+	fakeReturns := fake.createIsolationSegmentReturns
 	fake.recordInvocation("CreateIsolationSegment", []interface{}{arg1})
 	fake.createIsolationSegmentMutex.Unlock()
-	if fake.CreateIsolationSegmentStub != nil {
-		return fake.CreateIsolationSegmentStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createIsolationSegmentReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -362,15 +365,16 @@ func (fake *FakeCFClient) DefaultIsolationSegmentForOrg(arg1 string, arg2 string
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.DefaultIsolationSegmentForOrgStub
+	fakeReturns := fake.defaultIsolationSegmentForOrgReturns
 	fake.recordInvocation("DefaultIsolationSegmentForOrg", []interface{}{arg1, arg2})
 	fake.defaultIsolationSegmentForOrgMutex.Unlock()
-	if fake.DefaultIsolationSegmentForOrgStub != nil {
-		return fake.DefaultIsolationSegmentForOrgStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.defaultIsolationSegmentForOrgReturns
 	return fakeReturns.result1
 }
 
@@ -422,15 +426,16 @@ func (fake *FakeCFClient) DeleteIsolationSegmentByGUID(arg1 string) error {
 	fake.deleteIsolationSegmentByGUIDArgsForCall = append(fake.deleteIsolationSegmentByGUIDArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.DeleteIsolationSegmentByGUIDStub
+	fakeReturns := fake.deleteIsolationSegmentByGUIDReturns
 	fake.recordInvocation("DeleteIsolationSegmentByGUID", []interface{}{arg1})
 	fake.deleteIsolationSegmentByGUIDMutex.Unlock()
-	if fake.DeleteIsolationSegmentByGUIDStub != nil {
-		return fake.DeleteIsolationSegmentByGUIDStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteIsolationSegmentByGUIDReturns
 	return fakeReturns.result1
 }
 
@@ -482,15 +487,16 @@ func (fake *FakeCFClient) GetIsolationSegmentByGUID(arg1 string) (*cfclient.Isol
 	fake.getIsolationSegmentByGUIDArgsForCall = append(fake.getIsolationSegmentByGUIDArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetIsolationSegmentByGUIDStub
+	fakeReturns := fake.getIsolationSegmentByGUIDReturns
 	fake.recordInvocation("GetIsolationSegmentByGUID", []interface{}{arg1})
 	fake.getIsolationSegmentByGUIDMutex.Unlock()
-	if fake.GetIsolationSegmentByGUIDStub != nil {
-		return fake.GetIsolationSegmentByGUIDStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getIsolationSegmentByGUIDReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -546,15 +552,16 @@ func (fake *FakeCFClient) IsolationSegmentForSpace(arg1 string, arg2 string) err
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.IsolationSegmentForSpaceStub
+	fakeReturns := fake.isolationSegmentForSpaceReturns
 	fake.recordInvocation("IsolationSegmentForSpace", []interface{}{arg1, arg2})
 	fake.isolationSegmentForSpaceMutex.Unlock()
-	if fake.IsolationSegmentForSpaceStub != nil {
-		return fake.IsolationSegmentForSpaceStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isolationSegmentForSpaceReturns
 	return fakeReturns.result1
 }
 
@@ -605,15 +612,16 @@ func (fake *FakeCFClient) ListIsolationSegments() ([]cfclient.IsolationSegment, 
 	ret, specificReturn := fake.listIsolationSegmentsReturnsOnCall[len(fake.listIsolationSegmentsArgsForCall)]
 	fake.listIsolationSegmentsArgsForCall = append(fake.listIsolationSegmentsArgsForCall, struct {
 	}{})
+	stub := fake.ListIsolationSegmentsStub
+	fakeReturns := fake.listIsolationSegmentsReturns
 	fake.recordInvocation("ListIsolationSegments", []interface{}{})
 	fake.listIsolationSegmentsMutex.Unlock()
-	if fake.ListIsolationSegmentsStub != nil {
-		return fake.ListIsolationSegmentsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listIsolationSegmentsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -661,15 +669,16 @@ func (fake *FakeCFClient) ListIsolationSegmentsByQuery(arg1 url.Values) ([]cfcli
 	fake.listIsolationSegmentsByQueryArgsForCall = append(fake.listIsolationSegmentsByQueryArgsForCall, struct {
 		arg1 url.Values
 	}{arg1})
+	stub := fake.ListIsolationSegmentsByQueryStub
+	fakeReturns := fake.listIsolationSegmentsByQueryReturns
 	fake.recordInvocation("ListIsolationSegmentsByQuery", []interface{}{arg1})
 	fake.listIsolationSegmentsByQueryMutex.Unlock()
-	if fake.ListIsolationSegmentsByQueryStub != nil {
-		return fake.ListIsolationSegmentsByQueryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listIsolationSegmentsByQueryReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -725,15 +734,16 @@ func (fake *FakeCFClient) RemoveIsolationSegmentFromOrg(arg1 string, arg2 string
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RemoveIsolationSegmentFromOrgStub
+	fakeReturns := fake.removeIsolationSegmentFromOrgReturns
 	fake.recordInvocation("RemoveIsolationSegmentFromOrg", []interface{}{arg1, arg2})
 	fake.removeIsolationSegmentFromOrgMutex.Unlock()
-	if fake.RemoveIsolationSegmentFromOrgStub != nil {
-		return fake.RemoveIsolationSegmentFromOrgStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeIsolationSegmentFromOrgReturns
 	return fakeReturns.result1
 }
 
@@ -786,15 +796,16 @@ func (fake *FakeCFClient) RemoveIsolationSegmentFromSpace(arg1 string, arg2 stri
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RemoveIsolationSegmentFromSpaceStub
+	fakeReturns := fake.removeIsolationSegmentFromSpaceReturns
 	fake.recordInvocation("RemoveIsolationSegmentFromSpace", []interface{}{arg1, arg2})
 	fake.removeIsolationSegmentFromSpaceMutex.Unlock()
-	if fake.RemoveIsolationSegmentFromSpaceStub != nil {
-		return fake.RemoveIsolationSegmentFromSpaceStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeIsolationSegmentFromSpaceReturns
 	return fakeReturns.result1
 }
 
@@ -846,15 +857,16 @@ func (fake *FakeCFClient) ResetDefaultIsolationSegmentForOrg(arg1 string) error 
 	fake.resetDefaultIsolationSegmentForOrgArgsForCall = append(fake.resetDefaultIsolationSegmentForOrgArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ResetDefaultIsolationSegmentForOrgStub
+	fakeReturns := fake.resetDefaultIsolationSegmentForOrgReturns
 	fake.recordInvocation("ResetDefaultIsolationSegmentForOrg", []interface{}{arg1})
 	fake.resetDefaultIsolationSegmentForOrgMutex.Unlock()
-	if fake.ResetDefaultIsolationSegmentForOrgStub != nil {
-		return fake.ResetDefaultIsolationSegmentForOrgStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resetDefaultIsolationSegmentForOrgReturns
 	return fakeReturns.result1
 }
 
@@ -906,15 +918,16 @@ func (fake *FakeCFClient) ResetIsolationSegmentForSpace(arg1 string) error {
 	fake.resetIsolationSegmentForSpaceArgsForCall = append(fake.resetIsolationSegmentForSpaceArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ResetIsolationSegmentForSpaceStub
+	fakeReturns := fake.resetIsolationSegmentForSpaceReturns
 	fake.recordInvocation("ResetIsolationSegmentForSpace", []interface{}{arg1})
 	fake.resetIsolationSegmentForSpaceMutex.Unlock()
-	if fake.ResetIsolationSegmentForSpaceStub != nil {
-		return fake.ResetIsolationSegmentForSpaceStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resetIsolationSegmentForSpaceReturns
 	return fakeReturns.result1
 }
 

--- a/ldap/fakes/fake_connection.go
+++ b/ldap/fakes/fake_connection.go
@@ -44,9 +44,10 @@ func (fake *FakeConnection) Close() {
 	fake.closeMutex.Lock()
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
+	if stub != nil {
 		fake.CloseStub()
 	}
 }
@@ -68,15 +69,16 @@ func (fake *FakeConnection) IsClosing() bool {
 	ret, specificReturn := fake.isClosingReturnsOnCall[len(fake.isClosingArgsForCall)]
 	fake.isClosingArgsForCall = append(fake.isClosingArgsForCall, struct {
 	}{})
+	stub := fake.IsClosingStub
+	fakeReturns := fake.isClosingReturns
 	fake.recordInvocation("IsClosing", []interface{}{})
 	fake.isClosingMutex.Unlock()
-	if fake.IsClosingStub != nil {
-		return fake.IsClosingStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isClosingReturns
 	return fakeReturns.result1
 }
 
@@ -121,15 +123,16 @@ func (fake *FakeConnection) Search(arg1 *ldapa.SearchRequest) (*ldapa.SearchResu
 	fake.searchArgsForCall = append(fake.searchArgsForCall, struct {
 		arg1 *ldapa.SearchRequest
 	}{arg1})
+	stub := fake.SearchStub
+	fakeReturns := fake.searchReturns
 	fake.recordInvocation("Search", []interface{}{arg1})
 	fake.searchMutex.Unlock()
-	if fake.SearchStub != nil {
-		return fake.SearchStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.searchReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/organization/fakes/fake_cf_client.go
+++ b/organization/fakes/fake_cf_client.go
@@ -119,15 +119,16 @@ func (fake *FakeCFClient) CreateOrg(arg1 cfclient.OrgRequest) (cfclient.Org, err
 	fake.createOrgArgsForCall = append(fake.createOrgArgsForCall, struct {
 		arg1 cfclient.OrgRequest
 	}{arg1})
+	stub := fake.CreateOrgStub
+	fakeReturns := fake.createOrgReturns
 	fake.recordInvocation("CreateOrg", []interface{}{arg1})
 	fake.createOrgMutex.Unlock()
-	if fake.CreateOrgStub != nil {
-		return fake.CreateOrgStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createOrgReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -184,15 +185,16 @@ func (fake *FakeCFClient) DeleteOrg(arg1 string, arg2 bool, arg3 bool) error {
 		arg2 bool
 		arg3 bool
 	}{arg1, arg2, arg3})
+	stub := fake.DeleteOrgStub
+	fakeReturns := fake.deleteOrgReturns
 	fake.recordInvocation("DeleteOrg", []interface{}{arg1, arg2, arg3})
 	fake.deleteOrgMutex.Unlock()
-	if fake.DeleteOrgStub != nil {
-		return fake.DeleteOrgStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteOrgReturns
 	return fakeReturns.result1
 }
 
@@ -244,15 +246,16 @@ func (fake *FakeCFClient) OrgMetadata(arg1 string) (*cfclient.Metadata, error) {
 	fake.orgMetadataArgsForCall = append(fake.orgMetadataArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.OrgMetadataStub
+	fakeReturns := fake.orgMetadataReturns
 	fake.recordInvocation("OrgMetadata", []interface{}{arg1})
 	fake.orgMetadataMutex.Unlock()
-	if fake.OrgMetadataStub != nil {
-		return fake.OrgMetadataStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.orgMetadataReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -307,15 +310,16 @@ func (fake *FakeCFClient) RemoveOrgMetadata(arg1 string) error {
 	fake.removeOrgMetadataArgsForCall = append(fake.removeOrgMetadataArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RemoveOrgMetadataStub
+	fakeReturns := fake.removeOrgMetadataReturns
 	fake.recordInvocation("RemoveOrgMetadata", []interface{}{arg1})
 	fake.removeOrgMetadataMutex.Unlock()
-	if fake.RemoveOrgMetadataStub != nil {
-		return fake.RemoveOrgMetadataStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeOrgMetadataReturns
 	return fakeReturns.result1
 }
 
@@ -366,15 +370,16 @@ func (fake *FakeCFClient) SupportsMetadataAPI() (bool, error) {
 	ret, specificReturn := fake.supportsMetadataAPIReturnsOnCall[len(fake.supportsMetadataAPIArgsForCall)]
 	fake.supportsMetadataAPIArgsForCall = append(fake.supportsMetadataAPIArgsForCall, struct {
 	}{})
+	stub := fake.SupportsMetadataAPIStub
+	fakeReturns := fake.supportsMetadataAPIReturns
 	fake.recordInvocation("SupportsMetadataAPI", []interface{}{})
 	fake.supportsMetadataAPIMutex.Unlock()
-	if fake.SupportsMetadataAPIStub != nil {
-		return fake.SupportsMetadataAPIStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.supportsMetadataAPIReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -423,15 +428,16 @@ func (fake *FakeCFClient) UnshareOrgPrivateDomain(arg1 string, arg2 string) erro
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.UnshareOrgPrivateDomainStub
+	fakeReturns := fake.unshareOrgPrivateDomainReturns
 	fake.recordInvocation("UnshareOrgPrivateDomain", []interface{}{arg1, arg2})
 	fake.unshareOrgPrivateDomainMutex.Unlock()
-	if fake.UnshareOrgPrivateDomainStub != nil {
-		return fake.UnshareOrgPrivateDomainStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.unshareOrgPrivateDomainReturns
 	return fakeReturns.result1
 }
 
@@ -484,15 +490,16 @@ func (fake *FakeCFClient) UpdateOrg(arg1 string, arg2 cfclient.OrgRequest) (cfcl
 		arg1 string
 		arg2 cfclient.OrgRequest
 	}{arg1, arg2})
+	stub := fake.UpdateOrgStub
+	fakeReturns := fake.updateOrgReturns
 	fake.recordInvocation("UpdateOrg", []interface{}{arg1, arg2})
 	fake.updateOrgMutex.Unlock()
-	if fake.UpdateOrgStub != nil {
-		return fake.UpdateOrgStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.updateOrgReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -548,15 +555,16 @@ func (fake *FakeCFClient) UpdateOrgMetadata(arg1 string, arg2 cfclient.Metadata)
 		arg1 string
 		arg2 cfclient.Metadata
 	}{arg1, arg2})
+	stub := fake.UpdateOrgMetadataStub
+	fakeReturns := fake.updateOrgMetadataReturns
 	fake.recordInvocation("UpdateOrgMetadata", []interface{}{arg1, arg2})
 	fake.updateOrgMetadataMutex.Unlock()
-	if fake.UpdateOrgMetadataStub != nil {
-		return fake.UpdateOrgMetadataStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateOrgMetadataReturns
 	return fakeReturns.result1
 }
 

--- a/organization/fakes/fake_mgr.go
+++ b/organization/fakes/fake_mgr.go
@@ -74,15 +74,16 @@ func (fake *FakeManager) CreateOrgs() error {
 	ret, specificReturn := fake.createOrgsReturnsOnCall[len(fake.createOrgsArgsForCall)]
 	fake.createOrgsArgsForCall = append(fake.createOrgsArgsForCall, struct {
 	}{})
+	stub := fake.CreateOrgsStub
+	fakeReturns := fake.createOrgsReturns
 	fake.recordInvocation("CreateOrgs", []interface{}{})
 	fake.createOrgsMutex.Unlock()
-	if fake.CreateOrgsStub != nil {
-		return fake.CreateOrgsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createOrgsReturns
 	return fakeReturns.result1
 }
 
@@ -126,15 +127,16 @@ func (fake *FakeManager) DeleteOrgs() error {
 	ret, specificReturn := fake.deleteOrgsReturnsOnCall[len(fake.deleteOrgsArgsForCall)]
 	fake.deleteOrgsArgsForCall = append(fake.deleteOrgsArgsForCall, struct {
 	}{})
+	stub := fake.DeleteOrgsStub
+	fakeReturns := fake.deleteOrgsReturns
 	fake.recordInvocation("DeleteOrgs", []interface{}{})
 	fake.deleteOrgsMutex.Unlock()
-	if fake.DeleteOrgsStub != nil {
-		return fake.DeleteOrgsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteOrgsReturns
 	return fakeReturns.result1
 }
 
@@ -180,15 +182,16 @@ func (fake *FakeManager) RenameOrg(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RenameOrgStub
+	fakeReturns := fake.renameOrgReturns
 	fake.recordInvocation("RenameOrg", []interface{}{arg1, arg2})
 	fake.renameOrgMutex.Unlock()
-	if fake.RenameOrgStub != nil {
-		return fake.RenameOrgStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.renameOrgReturns
 	return fakeReturns.result1
 }
 
@@ -241,15 +244,16 @@ func (fake *FakeManager) UpdateOrg(arg1 string, arg2 cfclient.OrgRequest) (cfcli
 		arg1 string
 		arg2 cfclient.OrgRequest
 	}{arg1, arg2})
+	stub := fake.UpdateOrgStub
+	fakeReturns := fake.updateOrgReturns
 	fake.recordInvocation("UpdateOrg", []interface{}{arg1, arg2})
 	fake.updateOrgMutex.Unlock()
-	if fake.UpdateOrgStub != nil {
-		return fake.UpdateOrgStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.updateOrgReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -303,15 +307,16 @@ func (fake *FakeManager) UpdateOrgsMetadata() error {
 	ret, specificReturn := fake.updateOrgsMetadataReturnsOnCall[len(fake.updateOrgsMetadataArgsForCall)]
 	fake.updateOrgsMetadataArgsForCall = append(fake.updateOrgsMetadataArgsForCall, struct {
 	}{})
+	stub := fake.UpdateOrgsMetadataStub
+	fakeReturns := fake.updateOrgsMetadataReturns
 	fake.recordInvocation("UpdateOrgsMetadata", []interface{}{})
 	fake.updateOrgsMetadataMutex.Unlock()
-	if fake.UpdateOrgsMetadataStub != nil {
-		return fake.UpdateOrgsMetadataStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateOrgsMetadataReturns
 	return fakeReturns.result1
 }
 

--- a/organizationreader/fakes/fake_cf_client.go
+++ b/organizationreader/fakes/fake_cf_client.go
@@ -59,15 +59,16 @@ func (fake *FakeCFClient) DeleteOrg(arg1 string, arg2 bool, arg3 bool) error {
 		arg2 bool
 		arg3 bool
 	}{arg1, arg2, arg3})
+	stub := fake.DeleteOrgStub
+	fakeReturns := fake.deleteOrgReturns
 	fake.recordInvocation("DeleteOrg", []interface{}{arg1, arg2, arg3})
 	fake.deleteOrgMutex.Unlock()
-	if fake.DeleteOrgStub != nil {
-		return fake.DeleteOrgStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteOrgReturns
 	return fakeReturns.result1
 }
 
@@ -119,15 +120,16 @@ func (fake *FakeCFClient) GetOrgByGuid(arg1 string) (cfclient.Org, error) {
 	fake.getOrgByGuidArgsForCall = append(fake.getOrgByGuidArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetOrgByGuidStub
+	fakeReturns := fake.getOrgByGuidReturns
 	fake.recordInvocation("GetOrgByGuid", []interface{}{arg1})
 	fake.getOrgByGuidMutex.Unlock()
-	if fake.GetOrgByGuidStub != nil {
-		return fake.GetOrgByGuidStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getOrgByGuidReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -181,15 +183,16 @@ func (fake *FakeCFClient) ListOrgs() ([]cfclient.Org, error) {
 	ret, specificReturn := fake.listOrgsReturnsOnCall[len(fake.listOrgsArgsForCall)]
 	fake.listOrgsArgsForCall = append(fake.listOrgsArgsForCall, struct {
 	}{})
+	stub := fake.ListOrgsStub
+	fakeReturns := fake.listOrgsReturns
 	fake.recordInvocation("ListOrgs", []interface{}{})
 	fake.listOrgsMutex.Unlock()
-	if fake.ListOrgsStub != nil {
-		return fake.ListOrgsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listOrgsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/organizationreader/fakes/fake_reader.go
+++ b/organizationreader/fakes/fake_reader.go
@@ -91,9 +91,10 @@ func (fake *FakeReader) AddOrgToList(arg1 cfclient.Org) {
 	fake.addOrgToListArgsForCall = append(fake.addOrgToListArgsForCall, struct {
 		arg1 cfclient.Org
 	}{arg1})
+	stub := fake.AddOrgToListStub
 	fake.recordInvocation("AddOrgToList", []interface{}{arg1})
 	fake.addOrgToListMutex.Unlock()
-	if fake.AddOrgToListStub != nil {
+	if stub != nil {
 		fake.AddOrgToListStub(arg1)
 	}
 }
@@ -121,9 +122,10 @@ func (fake *FakeReader) ClearOrgList() {
 	fake.clearOrgListMutex.Lock()
 	fake.clearOrgListArgsForCall = append(fake.clearOrgListArgsForCall, struct {
 	}{})
+	stub := fake.ClearOrgListStub
 	fake.recordInvocation("ClearOrgList", []interface{}{})
 	fake.clearOrgListMutex.Unlock()
-	if fake.ClearOrgListStub != nil {
+	if stub != nil {
 		fake.ClearOrgListStub()
 	}
 }
@@ -146,15 +148,16 @@ func (fake *FakeReader) FindOrg(arg1 string) (cfclient.Org, error) {
 	fake.findOrgArgsForCall = append(fake.findOrgArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindOrgStub
+	fakeReturns := fake.findOrgReturns
 	fake.recordInvocation("FindOrg", []interface{}{arg1})
 	fake.findOrgMutex.Unlock()
-	if fake.FindOrgStub != nil {
-		return fake.FindOrgStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findOrgReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -209,15 +212,16 @@ func (fake *FakeReader) FindOrgByGUID(arg1 string) (cfclient.Org, error) {
 	fake.findOrgByGUIDArgsForCall = append(fake.findOrgByGUIDArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindOrgByGUIDStub
+	fakeReturns := fake.findOrgByGUIDReturns
 	fake.recordInvocation("FindOrgByGUID", []interface{}{arg1})
 	fake.findOrgByGUIDMutex.Unlock()
-	if fake.FindOrgByGUIDStub != nil {
-		return fake.FindOrgByGUIDStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findOrgByGUIDReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -272,15 +276,16 @@ func (fake *FakeReader) GetOrgByGUID(arg1 string) (cfclient.Org, error) {
 	fake.getOrgByGUIDArgsForCall = append(fake.getOrgByGUIDArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetOrgByGUIDStub
+	fakeReturns := fake.getOrgByGUIDReturns
 	fake.recordInvocation("GetOrgByGUID", []interface{}{arg1})
 	fake.getOrgByGUIDMutex.Unlock()
-	if fake.GetOrgByGUIDStub != nil {
-		return fake.GetOrgByGUIDStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getOrgByGUIDReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -335,15 +340,16 @@ func (fake *FakeReader) GetOrgGUID(arg1 string) (string, error) {
 	fake.getOrgGUIDArgsForCall = append(fake.getOrgGUIDArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetOrgGUIDStub
+	fakeReturns := fake.getOrgGUIDReturns
 	fake.recordInvocation("GetOrgGUID", []interface{}{arg1})
 	fake.getOrgGUIDMutex.Unlock()
-	if fake.GetOrgGUIDStub != nil {
-		return fake.GetOrgGUIDStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getOrgGUIDReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -397,15 +403,16 @@ func (fake *FakeReader) ListOrgs() ([]cfclient.Org, error) {
 	ret, specificReturn := fake.listOrgsReturnsOnCall[len(fake.listOrgsArgsForCall)]
 	fake.listOrgsArgsForCall = append(fake.listOrgsArgsForCall, struct {
 	}{})
+	stub := fake.ListOrgsStub
+	fakeReturns := fake.listOrgsReturns
 	fake.recordInvocation("ListOrgs", []interface{}{})
 	fake.listOrgsMutex.Unlock()
-	if fake.ListOrgsStub != nil {
-		return fake.ListOrgsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listOrgsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/privatedomain/fakes/fake_cf_client.go
+++ b/privatedomain/fakes/fake_cf_client.go
@@ -96,15 +96,16 @@ func (fake *FakeCFClient) CreateDomain(arg1 string, arg2 string) (*cfclient.Doma
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.CreateDomainStub
+	fakeReturns := fake.createDomainReturns
 	fake.recordInvocation("CreateDomain", []interface{}{arg1, arg2})
 	fake.createDomainMutex.Unlock()
-	if fake.CreateDomainStub != nil {
-		return fake.CreateDomainStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createDomainReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -159,15 +160,16 @@ func (fake *FakeCFClient) DeleteDomain(arg1 string) error {
 	fake.deleteDomainArgsForCall = append(fake.deleteDomainArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.DeleteDomainStub
+	fakeReturns := fake.deleteDomainReturns
 	fake.recordInvocation("DeleteDomain", []interface{}{arg1})
 	fake.deleteDomainMutex.Unlock()
-	if fake.DeleteDomainStub != nil {
-		return fake.DeleteDomainStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteDomainReturns
 	return fakeReturns.result1
 }
 
@@ -218,15 +220,16 @@ func (fake *FakeCFClient) ListDomains() ([]cfclient.Domain, error) {
 	ret, specificReturn := fake.listDomainsReturnsOnCall[len(fake.listDomainsArgsForCall)]
 	fake.listDomainsArgsForCall = append(fake.listDomainsArgsForCall, struct {
 	}{})
+	stub := fake.ListDomainsStub
+	fakeReturns := fake.listDomainsReturns
 	fake.recordInvocation("ListDomains", []interface{}{})
 	fake.listDomainsMutex.Unlock()
-	if fake.ListDomainsStub != nil {
-		return fake.ListDomainsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listDomainsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -274,15 +277,16 @@ func (fake *FakeCFClient) ListOrgPrivateDomains(arg1 string) ([]cfclient.Domain,
 	fake.listOrgPrivateDomainsArgsForCall = append(fake.listOrgPrivateDomainsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListOrgPrivateDomainsStub
+	fakeReturns := fake.listOrgPrivateDomainsReturns
 	fake.recordInvocation("ListOrgPrivateDomains", []interface{}{arg1})
 	fake.listOrgPrivateDomainsMutex.Unlock()
-	if fake.ListOrgPrivateDomainsStub != nil {
-		return fake.ListOrgPrivateDomainsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listOrgPrivateDomainsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -338,15 +342,16 @@ func (fake *FakeCFClient) ShareOrgPrivateDomain(arg1 string, arg2 string) (*cfcl
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.ShareOrgPrivateDomainStub
+	fakeReturns := fake.shareOrgPrivateDomainReturns
 	fake.recordInvocation("ShareOrgPrivateDomain", []interface{}{arg1, arg2})
 	fake.shareOrgPrivateDomainMutex.Unlock()
-	if fake.ShareOrgPrivateDomainStub != nil {
-		return fake.ShareOrgPrivateDomainStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.shareOrgPrivateDomainReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -402,15 +407,16 @@ func (fake *FakeCFClient) UnshareOrgPrivateDomain(arg1 string, arg2 string) erro
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.UnshareOrgPrivateDomainStub
+	fakeReturns := fake.unshareOrgPrivateDomainReturns
 	fake.recordInvocation("UnshareOrgPrivateDomain", []interface{}{arg1, arg2})
 	fake.unshareOrgPrivateDomainMutex.Unlock()
-	if fake.UnshareOrgPrivateDomainStub != nil {
-		return fake.UnshareOrgPrivateDomainStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.unshareOrgPrivateDomainReturns
 	return fakeReturns.result1
 }
 

--- a/privatedomain/fakes/fake_mgr.go
+++ b/privatedomain/fakes/fake_mgr.go
@@ -64,15 +64,16 @@ func (fake *FakeManager) CreatePrivateDomains() error {
 	ret, specificReturn := fake.createPrivateDomainsReturnsOnCall[len(fake.createPrivateDomainsArgsForCall)]
 	fake.createPrivateDomainsArgsForCall = append(fake.createPrivateDomainsArgsForCall, struct {
 	}{})
+	stub := fake.CreatePrivateDomainsStub
+	fakeReturns := fake.createPrivateDomainsReturns
 	fake.recordInvocation("CreatePrivateDomains", []interface{}{})
 	fake.createPrivateDomainsMutex.Unlock()
-	if fake.CreatePrivateDomainsStub != nil {
-		return fake.CreatePrivateDomainsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createPrivateDomainsReturns
 	return fakeReturns.result1
 }
 
@@ -117,15 +118,16 @@ func (fake *FakeManager) ListOrgOwnedPrivateDomains(arg1 string) (map[string]cfc
 	fake.listOrgOwnedPrivateDomainsArgsForCall = append(fake.listOrgOwnedPrivateDomainsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListOrgOwnedPrivateDomainsStub
+	fakeReturns := fake.listOrgOwnedPrivateDomainsReturns
 	fake.recordInvocation("ListOrgOwnedPrivateDomains", []interface{}{arg1})
 	fake.listOrgOwnedPrivateDomainsMutex.Unlock()
-	if fake.ListOrgOwnedPrivateDomainsStub != nil {
-		return fake.ListOrgOwnedPrivateDomainsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listOrgOwnedPrivateDomainsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -180,15 +182,16 @@ func (fake *FakeManager) ListOrgSharedPrivateDomains(arg1 string) (map[string]cf
 	fake.listOrgSharedPrivateDomainsArgsForCall = append(fake.listOrgSharedPrivateDomainsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListOrgSharedPrivateDomainsStub
+	fakeReturns := fake.listOrgSharedPrivateDomainsReturns
 	fake.recordInvocation("ListOrgSharedPrivateDomains", []interface{}{arg1})
 	fake.listOrgSharedPrivateDomainsMutex.Unlock()
-	if fake.ListOrgSharedPrivateDomainsStub != nil {
-		return fake.ListOrgSharedPrivateDomainsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listOrgSharedPrivateDomainsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -242,15 +245,16 @@ func (fake *FakeManager) SharePrivateDomains() error {
 	ret, specificReturn := fake.sharePrivateDomainsReturnsOnCall[len(fake.sharePrivateDomainsArgsForCall)]
 	fake.sharePrivateDomainsArgsForCall = append(fake.sharePrivateDomainsArgsForCall, struct {
 	}{})
+	stub := fake.SharePrivateDomainsStub
+	fakeReturns := fake.sharePrivateDomainsReturns
 	fake.recordInvocation("SharePrivateDomains", []interface{}{})
 	fake.sharePrivateDomainsMutex.Unlock()
-	if fake.SharePrivateDomainsStub != nil {
-		return fake.SharePrivateDomainsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.sharePrivateDomainsReturns
 	return fakeReturns.result1
 }
 

--- a/quota/fakes/fake_cf_client.go
+++ b/quota/fakes/fake_cf_client.go
@@ -137,15 +137,16 @@ func (fake *FakeCFClient) AssignSpaceQuota(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.AssignSpaceQuotaStub
+	fakeReturns := fake.assignSpaceQuotaReturns
 	fake.recordInvocation("AssignSpaceQuota", []interface{}{arg1, arg2})
 	fake.assignSpaceQuotaMutex.Unlock()
-	if fake.AssignSpaceQuotaStub != nil {
-		return fake.AssignSpaceQuotaStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.assignSpaceQuotaReturns
 	return fakeReturns.result1
 }
 
@@ -197,15 +198,16 @@ func (fake *FakeCFClient) CreateOrgQuota(arg1 cfclient.OrgQuotaRequest) (*cfclie
 	fake.createOrgQuotaArgsForCall = append(fake.createOrgQuotaArgsForCall, struct {
 		arg1 cfclient.OrgQuotaRequest
 	}{arg1})
+	stub := fake.CreateOrgQuotaStub
+	fakeReturns := fake.createOrgQuotaReturns
 	fake.recordInvocation("CreateOrgQuota", []interface{}{arg1})
 	fake.createOrgQuotaMutex.Unlock()
-	if fake.CreateOrgQuotaStub != nil {
-		return fake.CreateOrgQuotaStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createOrgQuotaReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -260,15 +262,16 @@ func (fake *FakeCFClient) CreateSpaceQuota(arg1 cfclient.SpaceQuotaRequest) (*cf
 	fake.createSpaceQuotaArgsForCall = append(fake.createSpaceQuotaArgsForCall, struct {
 		arg1 cfclient.SpaceQuotaRequest
 	}{arg1})
+	stub := fake.CreateSpaceQuotaStub
+	fakeReturns := fake.createSpaceQuotaReturns
 	fake.recordInvocation("CreateSpaceQuota", []interface{}{arg1})
 	fake.createSpaceQuotaMutex.Unlock()
-	if fake.CreateSpaceQuotaStub != nil {
-		return fake.CreateSpaceQuotaStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createSpaceQuotaReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -323,15 +326,16 @@ func (fake *FakeCFClient) GetOrgQuotaByName(arg1 string) (cfclient.OrgQuota, err
 	fake.getOrgQuotaByNameArgsForCall = append(fake.getOrgQuotaByNameArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetOrgQuotaByNameStub
+	fakeReturns := fake.getOrgQuotaByNameReturns
 	fake.recordInvocation("GetOrgQuotaByName", []interface{}{arg1})
 	fake.getOrgQuotaByNameMutex.Unlock()
-	if fake.GetOrgQuotaByNameStub != nil {
-		return fake.GetOrgQuotaByNameStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getOrgQuotaByNameReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -386,15 +390,16 @@ func (fake *FakeCFClient) GetSpaceQuotaByName(arg1 string) (cfclient.SpaceQuota,
 	fake.getSpaceQuotaByNameArgsForCall = append(fake.getSpaceQuotaByNameArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetSpaceQuotaByNameStub
+	fakeReturns := fake.getSpaceQuotaByNameReturns
 	fake.recordInvocation("GetSpaceQuotaByName", []interface{}{arg1})
 	fake.getSpaceQuotaByNameMutex.Unlock()
-	if fake.GetSpaceQuotaByNameStub != nil {
-		return fake.GetSpaceQuotaByNameStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSpaceQuotaByNameReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -448,15 +453,16 @@ func (fake *FakeCFClient) ListOrgQuotas() ([]cfclient.OrgQuota, error) {
 	ret, specificReturn := fake.listOrgQuotasReturnsOnCall[len(fake.listOrgQuotasArgsForCall)]
 	fake.listOrgQuotasArgsForCall = append(fake.listOrgQuotasArgsForCall, struct {
 	}{})
+	stub := fake.ListOrgQuotasStub
+	fakeReturns := fake.listOrgQuotasReturns
 	fake.recordInvocation("ListOrgQuotas", []interface{}{})
 	fake.listOrgQuotasMutex.Unlock()
-	if fake.ListOrgQuotasStub != nil {
-		return fake.ListOrgQuotasStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listOrgQuotasReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -504,15 +510,16 @@ func (fake *FakeCFClient) ListOrgSpaceQuotas(arg1 string) ([]cfclient.SpaceQuota
 	fake.listOrgSpaceQuotasArgsForCall = append(fake.listOrgSpaceQuotasArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListOrgSpaceQuotasStub
+	fakeReturns := fake.listOrgSpaceQuotasReturns
 	fake.recordInvocation("ListOrgSpaceQuotas", []interface{}{arg1})
 	fake.listOrgSpaceQuotasMutex.Unlock()
-	if fake.ListOrgSpaceQuotasStub != nil {
-		return fake.ListOrgSpaceQuotasStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listOrgSpaceQuotasReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -568,15 +575,16 @@ func (fake *FakeCFClient) UpdateOrgQuota(arg1 string, arg2 cfclient.OrgQuotaRequ
 		arg1 string
 		arg2 cfclient.OrgQuotaRequest
 	}{arg1, arg2})
+	stub := fake.UpdateOrgQuotaStub
+	fakeReturns := fake.updateOrgQuotaReturns
 	fake.recordInvocation("UpdateOrgQuota", []interface{}{arg1, arg2})
 	fake.updateOrgQuotaMutex.Unlock()
-	if fake.UpdateOrgQuotaStub != nil {
-		return fake.UpdateOrgQuotaStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.updateOrgQuotaReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -632,15 +640,16 @@ func (fake *FakeCFClient) UpdateSpaceQuota(arg1 string, arg2 cfclient.SpaceQuota
 		arg1 string
 		arg2 cfclient.SpaceQuotaRequest
 	}{arg1, arg2})
+	stub := fake.UpdateSpaceQuotaStub
+	fakeReturns := fake.updateSpaceQuotaReturns
 	fake.recordInvocation("UpdateSpaceQuota", []interface{}{arg1, arg2})
 	fake.updateSpaceQuotaMutex.Unlock()
-	if fake.UpdateSpaceQuotaStub != nil {
-		return fake.UpdateSpaceQuotaStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.updateSpaceQuotaReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/securitygroup/fakes/fake_cf_client.go
+++ b/securitygroup/fakes/fake_cf_client.go
@@ -156,15 +156,16 @@ func (fake *FakeCFClient) BindRunningSecGroup(arg1 string) error {
 	fake.bindRunningSecGroupArgsForCall = append(fake.bindRunningSecGroupArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.BindRunningSecGroupStub
+	fakeReturns := fake.bindRunningSecGroupReturns
 	fake.recordInvocation("BindRunningSecGroup", []interface{}{arg1})
 	fake.bindRunningSecGroupMutex.Unlock()
-	if fake.BindRunningSecGroupStub != nil {
-		return fake.BindRunningSecGroupStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.bindRunningSecGroupReturns
 	return fakeReturns.result1
 }
 
@@ -217,15 +218,16 @@ func (fake *FakeCFClient) BindSecGroup(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.BindSecGroupStub
+	fakeReturns := fake.bindSecGroupReturns
 	fake.recordInvocation("BindSecGroup", []interface{}{arg1, arg2})
 	fake.bindSecGroupMutex.Unlock()
-	if fake.BindSecGroupStub != nil {
-		return fake.BindSecGroupStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.bindSecGroupReturns
 	return fakeReturns.result1
 }
 
@@ -277,15 +279,16 @@ func (fake *FakeCFClient) BindStagingSecGroup(arg1 string) error {
 	fake.bindStagingSecGroupArgsForCall = append(fake.bindStagingSecGroupArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.BindStagingSecGroupStub
+	fakeReturns := fake.bindStagingSecGroupReturns
 	fake.recordInvocation("BindStagingSecGroup", []interface{}{arg1})
 	fake.bindStagingSecGroupMutex.Unlock()
-	if fake.BindStagingSecGroupStub != nil {
-		return fake.BindStagingSecGroupStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.bindStagingSecGroupReturns
 	return fakeReturns.result1
 }
 
@@ -349,15 +352,16 @@ func (fake *FakeCFClient) CreateSecGroup(arg1 string, arg2 []cfclient.SecGroupRu
 		arg2 []cfclient.SecGroupRule
 		arg3 []string
 	}{arg1, arg2Copy, arg3Copy})
+	stub := fake.CreateSecGroupStub
+	fakeReturns := fake.createSecGroupReturns
 	fake.recordInvocation("CreateSecGroup", []interface{}{arg1, arg2Copy, arg3Copy})
 	fake.createSecGroupMutex.Unlock()
-	if fake.CreateSecGroupStub != nil {
-		return fake.CreateSecGroupStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createSecGroupReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -412,15 +416,16 @@ func (fake *FakeCFClient) GetSecGroup(arg1 string) (*cfclient.SecGroup, error) {
 	fake.getSecGroupArgsForCall = append(fake.getSecGroupArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetSecGroupStub
+	fakeReturns := fake.getSecGroupReturns
 	fake.recordInvocation("GetSecGroup", []interface{}{arg1})
 	fake.getSecGroupMutex.Unlock()
-	if fake.GetSecGroupStub != nil {
-		return fake.GetSecGroupStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSecGroupReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -474,15 +479,16 @@ func (fake *FakeCFClient) ListSecGroups() ([]cfclient.SecGroup, error) {
 	ret, specificReturn := fake.listSecGroupsReturnsOnCall[len(fake.listSecGroupsArgsForCall)]
 	fake.listSecGroupsArgsForCall = append(fake.listSecGroupsArgsForCall, struct {
 	}{})
+	stub := fake.ListSecGroupsStub
+	fakeReturns := fake.listSecGroupsReturns
 	fake.recordInvocation("ListSecGroups", []interface{}{})
 	fake.listSecGroupsMutex.Unlock()
-	if fake.ListSecGroupsStub != nil {
-		return fake.ListSecGroupsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listSecGroupsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -530,15 +536,16 @@ func (fake *FakeCFClient) ListSpaceSecGroups(arg1 string) ([]cfclient.SecGroup, 
 	fake.listSpaceSecGroupsArgsForCall = append(fake.listSpaceSecGroupsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListSpaceSecGroupsStub
+	fakeReturns := fake.listSpaceSecGroupsReturns
 	fake.recordInvocation("ListSpaceSecGroups", []interface{}{arg1})
 	fake.listSpaceSecGroupsMutex.Unlock()
-	if fake.ListSpaceSecGroupsStub != nil {
-		return fake.ListSpaceSecGroupsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listSpaceSecGroupsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -593,15 +600,16 @@ func (fake *FakeCFClient) UnbindRunningSecGroup(arg1 string) error {
 	fake.unbindRunningSecGroupArgsForCall = append(fake.unbindRunningSecGroupArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.UnbindRunningSecGroupStub
+	fakeReturns := fake.unbindRunningSecGroupReturns
 	fake.recordInvocation("UnbindRunningSecGroup", []interface{}{arg1})
 	fake.unbindRunningSecGroupMutex.Unlock()
-	if fake.UnbindRunningSecGroupStub != nil {
-		return fake.UnbindRunningSecGroupStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.unbindRunningSecGroupReturns
 	return fakeReturns.result1
 }
 
@@ -654,15 +662,16 @@ func (fake *FakeCFClient) UnbindSecGroup(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.UnbindSecGroupStub
+	fakeReturns := fake.unbindSecGroupReturns
 	fake.recordInvocation("UnbindSecGroup", []interface{}{arg1, arg2})
 	fake.unbindSecGroupMutex.Unlock()
-	if fake.UnbindSecGroupStub != nil {
-		return fake.UnbindSecGroupStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.unbindSecGroupReturns
 	return fakeReturns.result1
 }
 
@@ -714,15 +723,16 @@ func (fake *FakeCFClient) UnbindStagingSecGroup(arg1 string) error {
 	fake.unbindStagingSecGroupArgsForCall = append(fake.unbindStagingSecGroupArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.UnbindStagingSecGroupStub
+	fakeReturns := fake.unbindStagingSecGroupReturns
 	fake.recordInvocation("UnbindStagingSecGroup", []interface{}{arg1})
 	fake.unbindStagingSecGroupMutex.Unlock()
-	if fake.UnbindStagingSecGroupStub != nil {
-		return fake.UnbindStagingSecGroupStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.unbindStagingSecGroupReturns
 	return fakeReturns.result1
 }
 
@@ -787,15 +797,16 @@ func (fake *FakeCFClient) UpdateSecGroup(arg1 string, arg2 string, arg3 []cfclie
 		arg3 []cfclient.SecGroupRule
 		arg4 []string
 	}{arg1, arg2, arg3Copy, arg4Copy})
+	stub := fake.UpdateSecGroupStub
+	fakeReturns := fake.updateSecGroupReturns
 	fake.recordInvocation("UpdateSecGroup", []interface{}{arg1, arg2, arg3Copy, arg4Copy})
 	fake.updateSecGroupMutex.Unlock()
-	if fake.UpdateSecGroupStub != nil {
-		return fake.UpdateSecGroupStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.updateSecGroupReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/securitygroup/fakes/fake_mgr.go
+++ b/securitygroup/fakes/fake_mgr.go
@@ -98,15 +98,16 @@ func (fake *FakeManager) AssignDefaultSecurityGroups() error {
 	ret, specificReturn := fake.assignDefaultSecurityGroupsReturnsOnCall[len(fake.assignDefaultSecurityGroupsArgsForCall)]
 	fake.assignDefaultSecurityGroupsArgsForCall = append(fake.assignDefaultSecurityGroupsArgsForCall, struct {
 	}{})
+	stub := fake.AssignDefaultSecurityGroupsStub
+	fakeReturns := fake.assignDefaultSecurityGroupsReturns
 	fake.recordInvocation("AssignDefaultSecurityGroups", []interface{}{})
 	fake.assignDefaultSecurityGroupsMutex.Unlock()
-	if fake.AssignDefaultSecurityGroupsStub != nil {
-		return fake.AssignDefaultSecurityGroupsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.assignDefaultSecurityGroupsReturns
 	return fakeReturns.result1
 }
 
@@ -150,15 +151,16 @@ func (fake *FakeManager) CreateApplicationSecurityGroups() error {
 	ret, specificReturn := fake.createApplicationSecurityGroupsReturnsOnCall[len(fake.createApplicationSecurityGroupsArgsForCall)]
 	fake.createApplicationSecurityGroupsArgsForCall = append(fake.createApplicationSecurityGroupsArgsForCall, struct {
 	}{})
+	stub := fake.CreateApplicationSecurityGroupsStub
+	fakeReturns := fake.createApplicationSecurityGroupsReturns
 	fake.recordInvocation("CreateApplicationSecurityGroups", []interface{}{})
 	fake.createApplicationSecurityGroupsMutex.Unlock()
-	if fake.CreateApplicationSecurityGroupsStub != nil {
-		return fake.CreateApplicationSecurityGroupsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createApplicationSecurityGroupsReturns
 	return fakeReturns.result1
 }
 
@@ -202,15 +204,16 @@ func (fake *FakeManager) CreateGlobalSecurityGroups() error {
 	ret, specificReturn := fake.createGlobalSecurityGroupsReturnsOnCall[len(fake.createGlobalSecurityGroupsArgsForCall)]
 	fake.createGlobalSecurityGroupsArgsForCall = append(fake.createGlobalSecurityGroupsArgsForCall, struct {
 	}{})
+	stub := fake.CreateGlobalSecurityGroupsStub
+	fakeReturns := fake.createGlobalSecurityGroupsReturns
 	fake.recordInvocation("CreateGlobalSecurityGroups", []interface{}{})
 	fake.createGlobalSecurityGroupsMutex.Unlock()
-	if fake.CreateGlobalSecurityGroupsStub != nil {
-		return fake.CreateGlobalSecurityGroupsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createGlobalSecurityGroupsReturns
 	return fakeReturns.result1
 }
 
@@ -255,15 +258,16 @@ func (fake *FakeManager) GetSecurityGroupRules(arg1 string) ([]byte, error) {
 	fake.getSecurityGroupRulesArgsForCall = append(fake.getSecurityGroupRulesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetSecurityGroupRulesStub
+	fakeReturns := fake.getSecurityGroupRulesReturns
 	fake.recordInvocation("GetSecurityGroupRules", []interface{}{arg1})
 	fake.getSecurityGroupRulesMutex.Unlock()
-	if fake.GetSecurityGroupRulesStub != nil {
-		return fake.GetSecurityGroupRulesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSecurityGroupRulesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -317,15 +321,16 @@ func (fake *FakeManager) ListDefaultSecurityGroups() (map[string]cfclient.SecGro
 	ret, specificReturn := fake.listDefaultSecurityGroupsReturnsOnCall[len(fake.listDefaultSecurityGroupsArgsForCall)]
 	fake.listDefaultSecurityGroupsArgsForCall = append(fake.listDefaultSecurityGroupsArgsForCall, struct {
 	}{})
+	stub := fake.ListDefaultSecurityGroupsStub
+	fakeReturns := fake.listDefaultSecurityGroupsReturns
 	fake.recordInvocation("ListDefaultSecurityGroups", []interface{}{})
 	fake.listDefaultSecurityGroupsMutex.Unlock()
-	if fake.ListDefaultSecurityGroupsStub != nil {
-		return fake.ListDefaultSecurityGroupsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listDefaultSecurityGroupsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -372,15 +377,16 @@ func (fake *FakeManager) ListNonDefaultSecurityGroups() (map[string]cfclient.Sec
 	ret, specificReturn := fake.listNonDefaultSecurityGroupsReturnsOnCall[len(fake.listNonDefaultSecurityGroupsArgsForCall)]
 	fake.listNonDefaultSecurityGroupsArgsForCall = append(fake.listNonDefaultSecurityGroupsArgsForCall, struct {
 	}{})
+	stub := fake.ListNonDefaultSecurityGroupsStub
+	fakeReturns := fake.listNonDefaultSecurityGroupsReturns
 	fake.recordInvocation("ListNonDefaultSecurityGroups", []interface{}{})
 	fake.listNonDefaultSecurityGroupsMutex.Unlock()
-	if fake.ListNonDefaultSecurityGroupsStub != nil {
-		return fake.ListNonDefaultSecurityGroupsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listNonDefaultSecurityGroupsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -428,15 +434,16 @@ func (fake *FakeManager) ListSpaceSecurityGroups(arg1 string) (map[string]string
 	fake.listSpaceSecurityGroupsArgsForCall = append(fake.listSpaceSecurityGroupsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListSpaceSecurityGroupsStub
+	fakeReturns := fake.listSpaceSecurityGroupsReturns
 	fake.recordInvocation("ListSpaceSecurityGroups", []interface{}{arg1})
 	fake.listSpaceSecurityGroupsMutex.Unlock()
-	if fake.ListSpaceSecurityGroupsStub != nil {
-		return fake.ListSpaceSecurityGroupsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listSpaceSecurityGroupsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/serviceaccess/fakes/fake_cf_client.go
+++ b/serviceaccess/fakes/fake_cf_client.go
@@ -133,15 +133,16 @@ func (fake *FakeCFClient) CreateServicePlanVisibility(arg1 string, arg2 string) 
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.CreateServicePlanVisibilityStub
+	fakeReturns := fake.createServicePlanVisibilityReturns
 	fake.recordInvocation("CreateServicePlanVisibility", []interface{}{arg1, arg2})
 	fake.createServicePlanVisibilityMutex.Unlock()
-	if fake.CreateServicePlanVisibilityStub != nil {
-		return fake.CreateServicePlanVisibilityStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createServicePlanVisibilityReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -198,15 +199,16 @@ func (fake *FakeCFClient) DeleteServicePlanVisibilityByPlanAndOrg(arg1 string, a
 		arg2 string
 		arg3 bool
 	}{arg1, arg2, arg3})
+	stub := fake.DeleteServicePlanVisibilityByPlanAndOrgStub
+	fakeReturns := fake.deleteServicePlanVisibilityByPlanAndOrgReturns
 	fake.recordInvocation("DeleteServicePlanVisibilityByPlanAndOrg", []interface{}{arg1, arg2, arg3})
 	fake.deleteServicePlanVisibilityByPlanAndOrgMutex.Unlock()
-	if fake.DeleteServicePlanVisibilityByPlanAndOrgStub != nil {
-		return fake.DeleteServicePlanVisibilityByPlanAndOrgStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteServicePlanVisibilityByPlanAndOrgReturns
 	return fakeReturns.result1
 }
 
@@ -257,15 +259,16 @@ func (fake *FakeCFClient) ListServiceBrokers() ([]cfclient.ServiceBroker, error)
 	ret, specificReturn := fake.listServiceBrokersReturnsOnCall[len(fake.listServiceBrokersArgsForCall)]
 	fake.listServiceBrokersArgsForCall = append(fake.listServiceBrokersArgsForCall, struct {
 	}{})
+	stub := fake.ListServiceBrokersStub
+	fakeReturns := fake.listServiceBrokersReturns
 	fake.recordInvocation("ListServiceBrokers", []interface{}{})
 	fake.listServiceBrokersMutex.Unlock()
-	if fake.ListServiceBrokersStub != nil {
-		return fake.ListServiceBrokersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listServiceBrokersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -313,15 +316,16 @@ func (fake *FakeCFClient) ListServicePlanVisibilitiesByQuery(arg1 url.Values) ([
 	fake.listServicePlanVisibilitiesByQueryArgsForCall = append(fake.listServicePlanVisibilitiesByQueryArgsForCall, struct {
 		arg1 url.Values
 	}{arg1})
+	stub := fake.ListServicePlanVisibilitiesByQueryStub
+	fakeReturns := fake.listServicePlanVisibilitiesByQueryReturns
 	fake.recordInvocation("ListServicePlanVisibilitiesByQuery", []interface{}{arg1})
 	fake.listServicePlanVisibilitiesByQueryMutex.Unlock()
-	if fake.ListServicePlanVisibilitiesByQueryStub != nil {
-		return fake.ListServicePlanVisibilitiesByQueryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listServicePlanVisibilitiesByQueryReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -376,15 +380,16 @@ func (fake *FakeCFClient) ListServicePlansByQuery(arg1 url.Values) ([]cfclient.S
 	fake.listServicePlansByQueryArgsForCall = append(fake.listServicePlansByQueryArgsForCall, struct {
 		arg1 url.Values
 	}{arg1})
+	stub := fake.ListServicePlansByQueryStub
+	fakeReturns := fake.listServicePlansByQueryReturns
 	fake.recordInvocation("ListServicePlansByQuery", []interface{}{arg1})
 	fake.listServicePlansByQueryMutex.Unlock()
-	if fake.ListServicePlansByQueryStub != nil {
-		return fake.ListServicePlansByQueryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listServicePlansByQueryReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -438,15 +443,16 @@ func (fake *FakeCFClient) ListServices() ([]cfclient.Service, error) {
 	ret, specificReturn := fake.listServicesReturnsOnCall[len(fake.listServicesArgsForCall)]
 	fake.listServicesArgsForCall = append(fake.listServicesArgsForCall, struct {
 	}{})
+	stub := fake.ListServicesStub
+	fakeReturns := fake.listServicesReturns
 	fake.recordInvocation("ListServices", []interface{}{})
 	fake.listServicesMutex.Unlock()
-	if fake.ListServicesStub != nil {
-		return fake.ListServicesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listServicesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -494,15 +500,16 @@ func (fake *FakeCFClient) ListServicesByQuery(arg1 url.Values) ([]cfclient.Servi
 	fake.listServicesByQueryArgsForCall = append(fake.listServicesByQueryArgsForCall, struct {
 		arg1 url.Values
 	}{arg1})
+	stub := fake.ListServicesByQueryStub
+	fakeReturns := fake.listServicesByQueryReturns
 	fake.recordInvocation("ListServicesByQuery", []interface{}{arg1})
 	fake.listServicesByQueryMutex.Unlock()
-	if fake.ListServicesByQueryStub != nil {
-		return fake.ListServicesByQueryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listServicesByQueryReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -557,15 +564,16 @@ func (fake *FakeCFClient) MakeServicePlanPrivate(arg1 string) error {
 	fake.makeServicePlanPrivateArgsForCall = append(fake.makeServicePlanPrivateArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.MakeServicePlanPrivateStub
+	fakeReturns := fake.makeServicePlanPrivateReturns
 	fake.recordInvocation("MakeServicePlanPrivate", []interface{}{arg1})
 	fake.makeServicePlanPrivateMutex.Unlock()
-	if fake.MakeServicePlanPrivateStub != nil {
-		return fake.MakeServicePlanPrivateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.makeServicePlanPrivateReturns
 	return fakeReturns.result1
 }
 
@@ -617,15 +625,16 @@ func (fake *FakeCFClient) MakeServicePlanPublic(arg1 string) error {
 	fake.makeServicePlanPublicArgsForCall = append(fake.makeServicePlanPublicArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.MakeServicePlanPublicStub
+	fakeReturns := fake.makeServicePlanPublicReturns
 	fake.recordInvocation("MakeServicePlanPublic", []interface{}{arg1})
 	fake.makeServicePlanPublicMutex.Unlock()
-	if fake.MakeServicePlanPublicStub != nil {
-		return fake.MakeServicePlanPublicStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.makeServicePlanPublicReturns
 	return fakeReturns.result1
 }
 

--- a/serviceaccess/legacy/fakes/fake_cf_client.go
+++ b/serviceaccess/legacy/fakes/fake_cf_client.go
@@ -97,15 +97,16 @@ func (fake *FakeCFClient) CreateServicePlanVisibility(arg1 string, arg2 string) 
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.CreateServicePlanVisibilityStub
+	fakeReturns := fake.createServicePlanVisibilityReturns
 	fake.recordInvocation("CreateServicePlanVisibility", []interface{}{arg1, arg2})
 	fake.createServicePlanVisibilityMutex.Unlock()
-	if fake.CreateServicePlanVisibilityStub != nil {
-		return fake.CreateServicePlanVisibilityStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createServicePlanVisibilityReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -162,15 +163,16 @@ func (fake *FakeCFClient) DeleteServicePlanVisibilityByPlanAndOrg(arg1 string, a
 		arg2 string
 		arg3 bool
 	}{arg1, arg2, arg3})
+	stub := fake.DeleteServicePlanVisibilityByPlanAndOrgStub
+	fakeReturns := fake.deleteServicePlanVisibilityByPlanAndOrgReturns
 	fake.recordInvocation("DeleteServicePlanVisibilityByPlanAndOrg", []interface{}{arg1, arg2, arg3})
 	fake.deleteServicePlanVisibilityByPlanAndOrgMutex.Unlock()
-	if fake.DeleteServicePlanVisibilityByPlanAndOrgStub != nil {
-		return fake.DeleteServicePlanVisibilityByPlanAndOrgStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteServicePlanVisibilityByPlanAndOrgReturns
 	return fakeReturns.result1
 }
 
@@ -222,15 +224,16 @@ func (fake *FakeCFClient) ListServicePlanVisibilitiesByQuery(arg1 url.Values) ([
 	fake.listServicePlanVisibilitiesByQueryArgsForCall = append(fake.listServicePlanVisibilitiesByQueryArgsForCall, struct {
 		arg1 url.Values
 	}{arg1})
+	stub := fake.ListServicePlanVisibilitiesByQueryStub
+	fakeReturns := fake.listServicePlanVisibilitiesByQueryReturns
 	fake.recordInvocation("ListServicePlanVisibilitiesByQuery", []interface{}{arg1})
 	fake.listServicePlanVisibilitiesByQueryMutex.Unlock()
-	if fake.ListServicePlanVisibilitiesByQueryStub != nil {
-		return fake.ListServicePlanVisibilitiesByQueryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listServicePlanVisibilitiesByQueryReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -285,15 +288,16 @@ func (fake *FakeCFClient) ListServicePlansByQuery(arg1 url.Values) ([]cfclient.S
 	fake.listServicePlansByQueryArgsForCall = append(fake.listServicePlansByQueryArgsForCall, struct {
 		arg1 url.Values
 	}{arg1})
+	stub := fake.ListServicePlansByQueryStub
+	fakeReturns := fake.listServicePlansByQueryReturns
 	fake.recordInvocation("ListServicePlansByQuery", []interface{}{arg1})
 	fake.listServicePlansByQueryMutex.Unlock()
-	if fake.ListServicePlansByQueryStub != nil {
-		return fake.ListServicePlansByQueryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listServicePlansByQueryReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -347,15 +351,16 @@ func (fake *FakeCFClient) ListServices() ([]cfclient.Service, error) {
 	ret, specificReturn := fake.listServicesReturnsOnCall[len(fake.listServicesArgsForCall)]
 	fake.listServicesArgsForCall = append(fake.listServicesArgsForCall, struct {
 	}{})
+	stub := fake.ListServicesStub
+	fakeReturns := fake.listServicesReturns
 	fake.recordInvocation("ListServices", []interface{}{})
 	fake.listServicesMutex.Unlock()
-	if fake.ListServicesStub != nil {
-		return fake.ListServicesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listServicesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -403,15 +408,16 @@ func (fake *FakeCFClient) MakeServicePlanPrivate(arg1 string) error {
 	fake.makeServicePlanPrivateArgsForCall = append(fake.makeServicePlanPrivateArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.MakeServicePlanPrivateStub
+	fakeReturns := fake.makeServicePlanPrivateReturns
 	fake.recordInvocation("MakeServicePlanPrivate", []interface{}{arg1})
 	fake.makeServicePlanPrivateMutex.Unlock()
-	if fake.MakeServicePlanPrivateStub != nil {
-		return fake.MakeServicePlanPrivateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.makeServicePlanPrivateReturns
 	return fakeReturns.result1
 }
 

--- a/shareddomain/fakes/fake_cf_client.go
+++ b/shareddomain/fakes/fake_cf_client.go
@@ -60,15 +60,16 @@ func (fake *FakeCFClient) CreateSharedDomain(arg1 string, arg2 bool, arg3 string
 		arg2 bool
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.CreateSharedDomainStub
+	fakeReturns := fake.createSharedDomainReturns
 	fake.recordInvocation("CreateSharedDomain", []interface{}{arg1, arg2, arg3})
 	fake.createSharedDomainMutex.Unlock()
-	if fake.CreateSharedDomainStub != nil {
-		return fake.CreateSharedDomainStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createSharedDomainReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -124,15 +125,16 @@ func (fake *FakeCFClient) DeleteSharedDomain(arg1 string, arg2 bool) error {
 		arg1 string
 		arg2 bool
 	}{arg1, arg2})
+	stub := fake.DeleteSharedDomainStub
+	fakeReturns := fake.deleteSharedDomainReturns
 	fake.recordInvocation("DeleteSharedDomain", []interface{}{arg1, arg2})
 	fake.deleteSharedDomainMutex.Unlock()
-	if fake.DeleteSharedDomainStub != nil {
-		return fake.DeleteSharedDomainStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteSharedDomainReturns
 	return fakeReturns.result1
 }
 
@@ -183,15 +185,16 @@ func (fake *FakeCFClient) ListSharedDomains() ([]cfclient.SharedDomain, error) {
 	ret, specificReturn := fake.listSharedDomainsReturnsOnCall[len(fake.listSharedDomainsArgsForCall)]
 	fake.listSharedDomainsArgsForCall = append(fake.listSharedDomainsArgsForCall, struct {
 	}{})
+	stub := fake.ListSharedDomainsStub
+	fakeReturns := fake.listSharedDomainsReturns
 	fake.recordInvocation("ListSharedDomains", []interface{}{})
 	fake.listSharedDomainsMutex.Unlock()
-	if fake.ListSharedDomainsStub != nil {
-		return fake.ListSharedDomainsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listSharedDomainsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/shareddomain/fakes/fake_routing_client.go
+++ b/shareddomain/fakes/fake_routing_client.go
@@ -44,15 +44,16 @@ func (fake *FakeRoutingClient) RouterGroupWithName(arg1 string) (models.RouterGr
 	fake.routerGroupWithNameArgsForCall = append(fake.routerGroupWithNameArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RouterGroupWithNameStub
+	fakeReturns := fake.routerGroupWithNameReturns
 	fake.recordInvocation("RouterGroupWithName", []interface{}{arg1})
 	fake.routerGroupWithNameMutex.Unlock()
-	if fake.RouterGroupWithNameStub != nil {
-		return fake.RouterGroupWithNameStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.routerGroupWithNameReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -106,15 +107,16 @@ func (fake *FakeRoutingClient) RouterGroups() ([]models.RouterGroup, error) {
 	ret, specificReturn := fake.routerGroupsReturnsOnCall[len(fake.routerGroupsArgsForCall)]
 	fake.routerGroupsArgsForCall = append(fake.routerGroupsArgsForCall, struct {
 	}{})
+	stub := fake.RouterGroupsStub
+	fakeReturns := fake.routerGroupsReturns
 	fake.recordInvocation("RouterGroups", []interface{}{})
 	fake.routerGroupsMutex.Unlock()
-	if fake.RouterGroupsStub != nil {
-		return fake.RouterGroupsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.routerGroupsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/space/fakes/fake_cf_client.go
+++ b/space/fakes/fake_cf_client.go
@@ -144,15 +144,16 @@ func (fake *FakeCFClient) CreateSpace(arg1 cfclient.SpaceRequest) (cfclient.Spac
 	fake.createSpaceArgsForCall = append(fake.createSpaceArgsForCall, struct {
 		arg1 cfclient.SpaceRequest
 	}{arg1})
+	stub := fake.CreateSpaceStub
+	fakeReturns := fake.createSpaceReturns
 	fake.recordInvocation("CreateSpace", []interface{}{arg1})
 	fake.createSpaceMutex.Unlock()
-	if fake.CreateSpaceStub != nil {
-		return fake.CreateSpaceStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createSpaceReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -209,15 +210,16 @@ func (fake *FakeCFClient) DeleteSpace(arg1 string, arg2 bool, arg3 bool) error {
 		arg2 bool
 		arg3 bool
 	}{arg1, arg2, arg3})
+	stub := fake.DeleteSpaceStub
+	fakeReturns := fake.deleteSpaceReturns
 	fake.recordInvocation("DeleteSpace", []interface{}{arg1, arg2, arg3})
 	fake.deleteSpaceMutex.Unlock()
-	if fake.DeleteSpaceStub != nil {
-		return fake.DeleteSpaceStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteSpaceReturns
 	return fakeReturns.result1
 }
 
@@ -269,15 +271,16 @@ func (fake *FakeCFClient) GetSpaceByGuid(arg1 string) (cfclient.Space, error) {
 	fake.getSpaceByGuidArgsForCall = append(fake.getSpaceByGuidArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetSpaceByGuidStub
+	fakeReturns := fake.getSpaceByGuidReturns
 	fake.recordInvocation("GetSpaceByGuid", []interface{}{arg1})
 	fake.getSpaceByGuidMutex.Unlock()
-	if fake.GetSpaceByGuidStub != nil {
-		return fake.GetSpaceByGuidStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSpaceByGuidReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -331,15 +334,16 @@ func (fake *FakeCFClient) ListOrgs() ([]cfclient.Org, error) {
 	ret, specificReturn := fake.listOrgsReturnsOnCall[len(fake.listOrgsArgsForCall)]
 	fake.listOrgsArgsForCall = append(fake.listOrgsArgsForCall, struct {
 	}{})
+	stub := fake.ListOrgsStub
+	fakeReturns := fake.listOrgsReturns
 	fake.recordInvocation("ListOrgs", []interface{}{})
 	fake.listOrgsMutex.Unlock()
-	if fake.ListOrgsStub != nil {
-		return fake.ListOrgsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listOrgsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -386,15 +390,16 @@ func (fake *FakeCFClient) ListSpaces() ([]cfclient.Space, error) {
 	ret, specificReturn := fake.listSpacesReturnsOnCall[len(fake.listSpacesArgsForCall)]
 	fake.listSpacesArgsForCall = append(fake.listSpacesArgsForCall, struct {
 	}{})
+	stub := fake.ListSpacesStub
+	fakeReturns := fake.listSpacesReturns
 	fake.recordInvocation("ListSpaces", []interface{}{})
 	fake.listSpacesMutex.Unlock()
-	if fake.ListSpacesStub != nil {
-		return fake.ListSpacesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listSpacesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -442,15 +447,16 @@ func (fake *FakeCFClient) RemoveSpaceMetadata(arg1 string) error {
 	fake.removeSpaceMetadataArgsForCall = append(fake.removeSpaceMetadataArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RemoveSpaceMetadataStub
+	fakeReturns := fake.removeSpaceMetadataReturns
 	fake.recordInvocation("RemoveSpaceMetadata", []interface{}{arg1})
 	fake.removeSpaceMetadataMutex.Unlock()
-	if fake.RemoveSpaceMetadataStub != nil {
-		return fake.RemoveSpaceMetadataStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeSpaceMetadataReturns
 	return fakeReturns.result1
 }
 
@@ -502,15 +508,16 @@ func (fake *FakeCFClient) SpaceMetadata(arg1 string) (*cfclient.Metadata, error)
 	fake.spaceMetadataArgsForCall = append(fake.spaceMetadataArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.SpaceMetadataStub
+	fakeReturns := fake.spaceMetadataReturns
 	fake.recordInvocation("SpaceMetadata", []interface{}{arg1})
 	fake.spaceMetadataMutex.Unlock()
-	if fake.SpaceMetadataStub != nil {
-		return fake.SpaceMetadataStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.spaceMetadataReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -564,15 +571,16 @@ func (fake *FakeCFClient) SupportsMetadataAPI() (bool, error) {
 	ret, specificReturn := fake.supportsMetadataAPIReturnsOnCall[len(fake.supportsMetadataAPIArgsForCall)]
 	fake.supportsMetadataAPIArgsForCall = append(fake.supportsMetadataAPIArgsForCall, struct {
 	}{})
+	stub := fake.SupportsMetadataAPIStub
+	fakeReturns := fake.supportsMetadataAPIReturns
 	fake.recordInvocation("SupportsMetadataAPI", []interface{}{})
 	fake.supportsMetadataAPIMutex.Unlock()
-	if fake.SupportsMetadataAPIStub != nil {
-		return fake.SupportsMetadataAPIStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.supportsMetadataAPIReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -621,15 +629,16 @@ func (fake *FakeCFClient) UpdateSpace(arg1 string, arg2 cfclient.SpaceRequest) (
 		arg1 string
 		arg2 cfclient.SpaceRequest
 	}{arg1, arg2})
+	stub := fake.UpdateSpaceStub
+	fakeReturns := fake.updateSpaceReturns
 	fake.recordInvocation("UpdateSpace", []interface{}{arg1, arg2})
 	fake.updateSpaceMutex.Unlock()
-	if fake.UpdateSpaceStub != nil {
-		return fake.UpdateSpaceStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.updateSpaceReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -685,15 +694,16 @@ func (fake *FakeCFClient) UpdateSpaceMetadata(arg1 string, arg2 cfclient.Metadat
 		arg1 string
 		arg2 cfclient.Metadata
 	}{arg1, arg2})
+	stub := fake.UpdateSpaceMetadataStub
+	fakeReturns := fake.updateSpaceMetadataReturns
 	fake.recordInvocation("UpdateSpaceMetadata", []interface{}{arg1, arg2})
 	fake.updateSpaceMetadataMutex.Unlock()
-	if fake.UpdateSpaceMetadataStub != nil {
-		return fake.UpdateSpaceMetadataStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateSpaceMetadataReturns
 	return fakeReturns.result1
 }
 

--- a/space/fakes/fake_mgr.go
+++ b/space/fakes/fake_mgr.go
@@ -55,6 +55,19 @@ type FakeManager struct {
 		result1 cfclient.Space
 		result2 error
 	}
+	GetSpaceMetadataStub        func(string) (*cfclient.Metadata, error)
+	getSpaceMetadataMutex       sync.RWMutex
+	getSpaceMetadataArgsForCall []struct {
+		arg1 string
+	}
+	getSpaceMetadataReturns struct {
+		result1 *cfclient.Metadata
+		result2 error
+	}
+	getSpaceMetadataReturnsOnCall map[int]struct {
+		result1 *cfclient.Metadata
+		result2 error
+	}
 	ListSpacesStub        func(string) ([]cfclient.Space, error)
 	listSpacesMutex       sync.RWMutex
 	listSpacesArgsForCall []struct {
@@ -97,15 +110,16 @@ func (fake *FakeManager) CreateSpaces() error {
 	ret, specificReturn := fake.createSpacesReturnsOnCall[len(fake.createSpacesArgsForCall)]
 	fake.createSpacesArgsForCall = append(fake.createSpacesArgsForCall, struct {
 	}{})
+	stub := fake.CreateSpacesStub
+	fakeReturns := fake.createSpacesReturns
 	fake.recordInvocation("CreateSpaces", []interface{}{})
 	fake.createSpacesMutex.Unlock()
-	if fake.CreateSpacesStub != nil {
-		return fake.CreateSpacesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createSpacesReturns
 	return fakeReturns.result1
 }
 
@@ -149,15 +163,16 @@ func (fake *FakeManager) DeleteSpaces() error {
 	ret, specificReturn := fake.deleteSpacesReturnsOnCall[len(fake.deleteSpacesArgsForCall)]
 	fake.deleteSpacesArgsForCall = append(fake.deleteSpacesArgsForCall, struct {
 	}{})
+	stub := fake.DeleteSpacesStub
+	fakeReturns := fake.deleteSpacesReturns
 	fake.recordInvocation("DeleteSpaces", []interface{}{})
 	fake.deleteSpacesMutex.Unlock()
-	if fake.DeleteSpacesStub != nil {
-		return fake.DeleteSpacesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteSpacesReturns
 	return fakeReturns.result1
 }
 
@@ -203,15 +218,16 @@ func (fake *FakeManager) DeleteSpacesForOrg(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.DeleteSpacesForOrgStub
+	fakeReturns := fake.deleteSpacesForOrgReturns
 	fake.recordInvocation("DeleteSpacesForOrg", []interface{}{arg1, arg2})
 	fake.deleteSpacesForOrgMutex.Unlock()
-	if fake.DeleteSpacesForOrgStub != nil {
-		return fake.DeleteSpacesForOrgStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteSpacesForOrgReturns
 	return fakeReturns.result1
 }
 
@@ -264,15 +280,16 @@ func (fake *FakeManager) FindSpace(arg1 string, arg2 string) (cfclient.Space, er
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.FindSpaceStub
+	fakeReturns := fake.findSpaceReturns
 	fake.recordInvocation("FindSpace", []interface{}{arg1, arg2})
 	fake.findSpaceMutex.Unlock()
-	if fake.FindSpaceStub != nil {
-		return fake.FindSpaceStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findSpaceReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -321,21 +338,86 @@ func (fake *FakeManager) FindSpaceReturnsOnCall(i int, result1 cfclient.Space, r
 	}{result1, result2}
 }
 
+func (fake *FakeManager) GetSpaceMetadata(arg1 string) (*cfclient.Metadata, error) {
+	fake.getSpaceMetadataMutex.Lock()
+	ret, specificReturn := fake.getSpaceMetadataReturnsOnCall[len(fake.getSpaceMetadataArgsForCall)]
+	fake.getSpaceMetadataArgsForCall = append(fake.getSpaceMetadataArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.GetSpaceMetadataStub
+	fakeReturns := fake.getSpaceMetadataReturns
+	fake.recordInvocation("GetSpaceMetadata", []interface{}{arg1})
+	fake.getSpaceMetadataMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeManager) GetSpaceMetadataCallCount() int {
+	fake.getSpaceMetadataMutex.RLock()
+	defer fake.getSpaceMetadataMutex.RUnlock()
+	return len(fake.getSpaceMetadataArgsForCall)
+}
+
+func (fake *FakeManager) GetSpaceMetadataCalls(stub func(string) (*cfclient.Metadata, error)) {
+	fake.getSpaceMetadataMutex.Lock()
+	defer fake.getSpaceMetadataMutex.Unlock()
+	fake.GetSpaceMetadataStub = stub
+}
+
+func (fake *FakeManager) GetSpaceMetadataArgsForCall(i int) string {
+	fake.getSpaceMetadataMutex.RLock()
+	defer fake.getSpaceMetadataMutex.RUnlock()
+	argsForCall := fake.getSpaceMetadataArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeManager) GetSpaceMetadataReturns(result1 *cfclient.Metadata, result2 error) {
+	fake.getSpaceMetadataMutex.Lock()
+	defer fake.getSpaceMetadataMutex.Unlock()
+	fake.GetSpaceMetadataStub = nil
+	fake.getSpaceMetadataReturns = struct {
+		result1 *cfclient.Metadata
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeManager) GetSpaceMetadataReturnsOnCall(i int, result1 *cfclient.Metadata, result2 error) {
+	fake.getSpaceMetadataMutex.Lock()
+	defer fake.getSpaceMetadataMutex.Unlock()
+	fake.GetSpaceMetadataStub = nil
+	if fake.getSpaceMetadataReturnsOnCall == nil {
+		fake.getSpaceMetadataReturnsOnCall = make(map[int]struct {
+			result1 *cfclient.Metadata
+			result2 error
+		})
+	}
+	fake.getSpaceMetadataReturnsOnCall[i] = struct {
+		result1 *cfclient.Metadata
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeManager) ListSpaces(arg1 string) ([]cfclient.Space, error) {
 	fake.listSpacesMutex.Lock()
 	ret, specificReturn := fake.listSpacesReturnsOnCall[len(fake.listSpacesArgsForCall)]
 	fake.listSpacesArgsForCall = append(fake.listSpacesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListSpacesStub
+	fakeReturns := fake.listSpacesReturns
 	fake.recordInvocation("ListSpaces", []interface{}{arg1})
 	fake.listSpacesMutex.Unlock()
-	if fake.ListSpacesStub != nil {
-		return fake.ListSpacesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listSpacesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -389,15 +471,16 @@ func (fake *FakeManager) UpdateSpaces() error {
 	ret, specificReturn := fake.updateSpacesReturnsOnCall[len(fake.updateSpacesArgsForCall)]
 	fake.updateSpacesArgsForCall = append(fake.updateSpacesArgsForCall, struct {
 	}{})
+	stub := fake.UpdateSpacesStub
+	fakeReturns := fake.updateSpacesReturns
 	fake.recordInvocation("UpdateSpaces", []interface{}{})
 	fake.updateSpacesMutex.Unlock()
-	if fake.UpdateSpacesStub != nil {
-		return fake.UpdateSpacesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateSpacesReturns
 	return fakeReturns.result1
 }
 
@@ -441,15 +524,16 @@ func (fake *FakeManager) UpdateSpacesMetadata() error {
 	ret, specificReturn := fake.updateSpacesMetadataReturnsOnCall[len(fake.updateSpacesMetadataArgsForCall)]
 	fake.updateSpacesMetadataArgsForCall = append(fake.updateSpacesMetadataArgsForCall, struct {
 	}{})
+	stub := fake.UpdateSpacesMetadataStub
+	fakeReturns := fake.updateSpacesMetadataReturns
 	fake.recordInvocation("UpdateSpacesMetadata", []interface{}{})
 	fake.updateSpacesMetadataMutex.Unlock()
-	if fake.UpdateSpacesMetadataStub != nil {
-		return fake.UpdateSpacesMetadataStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateSpacesMetadataReturns
 	return fakeReturns.result1
 }
 
@@ -499,6 +583,8 @@ func (fake *FakeManager) Invocations() map[string][][]interface{} {
 	defer fake.deleteSpacesForOrgMutex.RUnlock()
 	fake.findSpaceMutex.RLock()
 	defer fake.findSpaceMutex.RUnlock()
+	fake.getSpaceMetadataMutex.RLock()
+	defer fake.getSpaceMetadataMutex.RUnlock()
 	fake.listSpacesMutex.RLock()
 	defer fake.listSpacesMutex.RUnlock()
 	fake.updateSpacesMutex.RLock()

--- a/space/spaces.go
+++ b/space/spaces.go
@@ -338,6 +338,10 @@ func (m *DefaultManager) DeleteSpace(space cfclient.Space, orgName string) error
 	return m.Client.DeleteSpace(space.Guid, true, false)
 }
 
+func (m *DefaultManager) GetSpaceMetadata(spaceGUID string) (*cfclient.Metadata, error) {
+	return m.Client.SpaceMetadata(spaceGUID)
+}
+
 func (m *DefaultManager) UpdateSpacesMetadata() error {
 	supports, err := m.Client.SupportsMetadataAPI()
 	if err != nil {

--- a/space/types.go
+++ b/space/types.go
@@ -12,6 +12,7 @@ type Manager interface {
 	DeleteSpaces() (err error)
 	DeleteSpacesForOrg(orgGUID, orgName string) (err error)
 	ListSpaces(orgGUID string) ([]cfclient.Space, error)
+	GetSpaceMetadata(spaceGUID string) (*cfclient.Metadata, error)
 	UpdateSpacesMetadata() error
 }
 

--- a/uaa/fakes/fake_mgr.go
+++ b/uaa/fakes/fake_mgr.go
@@ -49,15 +49,16 @@ func (fake *FakeManager) CreateExternalUser(arg1 string, arg2 string, arg3 strin
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.CreateExternalUserStub
+	fakeReturns := fake.createExternalUserReturns
 	fake.recordInvocation("CreateExternalUser", []interface{}{arg1, arg2, arg3, arg4})
 	fake.createExternalUserMutex.Unlock()
-	if fake.CreateExternalUserStub != nil {
-		return fake.CreateExternalUserStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createExternalUserReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -111,15 +112,16 @@ func (fake *FakeManager) ListUsers() (*uaa.Users, error) {
 	ret, specificReturn := fake.listUsersReturnsOnCall[len(fake.listUsersArgsForCall)]
 	fake.listUsersArgsForCall = append(fake.listUsersArgsForCall, struct {
 	}{})
+	stub := fake.ListUsersStub
+	fakeReturns := fake.listUsersReturns
 	fake.recordInvocation("ListUsers", []interface{}{})
 	fake.listUsersMutex.Unlock()
-	if fake.ListUsersStub != nil {
-		return fake.ListUsersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listUsersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/uaa/fakes/uaa_client.go
+++ b/uaa/fakes/uaa_client.go
@@ -47,15 +47,16 @@ func (fake *FakeUaa) CreateUser(arg1 uaaa.User) (*uaaa.User, error) {
 	fake.createUserArgsForCall = append(fake.createUserArgsForCall, struct {
 		arg1 uaaa.User
 	}{arg1})
+	stub := fake.CreateUserStub
+	fakeReturns := fake.createUserReturns
 	fake.recordInvocation("CreateUser", []interface{}{arg1})
 	fake.createUserMutex.Unlock()
-	if fake.CreateUserStub != nil {
-		return fake.CreateUserStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createUserReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -113,15 +114,16 @@ func (fake *FakeUaa) ListAllUsers(arg1 string, arg2 string, arg3 string, arg4 ua
 		arg3 string
 		arg4 uaaa.SortOrder
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.ListAllUsersStub
+	fakeReturns := fake.listAllUsersReturns
 	fake.recordInvocation("ListAllUsers", []interface{}{arg1, arg2, arg3, arg4})
 	fake.listAllUsersMutex.Unlock()
-	if fake.ListAllUsersStub != nil {
-		return fake.ListAllUsersStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listAllUsersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/user/fakes/fake_cf_client.go
+++ b/user/fakes/fake_cf_client.go
@@ -318,15 +318,16 @@ func (fake *FakeCFClient) AssociateOrgAuditor(arg1 string, arg2 string) (cfclien
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.AssociateOrgAuditorStub
+	fakeReturns := fake.associateOrgAuditorReturns
 	fake.recordInvocation("AssociateOrgAuditor", []interface{}{arg1, arg2})
 	fake.associateOrgAuditorMutex.Unlock()
-	if fake.AssociateOrgAuditorStub != nil {
-		return fake.AssociateOrgAuditorStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.associateOrgAuditorReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -382,15 +383,16 @@ func (fake *FakeCFClient) AssociateOrgBillingManager(arg1 string, arg2 string) (
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.AssociateOrgBillingManagerStub
+	fakeReturns := fake.associateOrgBillingManagerReturns
 	fake.recordInvocation("AssociateOrgBillingManager", []interface{}{arg1, arg2})
 	fake.associateOrgBillingManagerMutex.Unlock()
-	if fake.AssociateOrgBillingManagerStub != nil {
-		return fake.AssociateOrgBillingManagerStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.associateOrgBillingManagerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -446,15 +448,16 @@ func (fake *FakeCFClient) AssociateOrgManager(arg1 string, arg2 string) (cfclien
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.AssociateOrgManagerStub
+	fakeReturns := fake.associateOrgManagerReturns
 	fake.recordInvocation("AssociateOrgManager", []interface{}{arg1, arg2})
 	fake.associateOrgManagerMutex.Unlock()
-	if fake.AssociateOrgManagerStub != nil {
-		return fake.AssociateOrgManagerStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.associateOrgManagerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -510,15 +513,16 @@ func (fake *FakeCFClient) AssociateOrgUser(arg1 string, arg2 string) (cfclient.O
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.AssociateOrgUserStub
+	fakeReturns := fake.associateOrgUserReturns
 	fake.recordInvocation("AssociateOrgUser", []interface{}{arg1, arg2})
 	fake.associateOrgUserMutex.Unlock()
-	if fake.AssociateOrgUserStub != nil {
-		return fake.AssociateOrgUserStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.associateOrgUserReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -574,15 +578,16 @@ func (fake *FakeCFClient) AssociateSpaceAuditor(arg1 string, arg2 string) (cfcli
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.AssociateSpaceAuditorStub
+	fakeReturns := fake.associateSpaceAuditorReturns
 	fake.recordInvocation("AssociateSpaceAuditor", []interface{}{arg1, arg2})
 	fake.associateSpaceAuditorMutex.Unlock()
-	if fake.AssociateSpaceAuditorStub != nil {
-		return fake.AssociateSpaceAuditorStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.associateSpaceAuditorReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -638,15 +643,16 @@ func (fake *FakeCFClient) AssociateSpaceDeveloper(arg1 string, arg2 string) (cfc
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.AssociateSpaceDeveloperStub
+	fakeReturns := fake.associateSpaceDeveloperReturns
 	fake.recordInvocation("AssociateSpaceDeveloper", []interface{}{arg1, arg2})
 	fake.associateSpaceDeveloperMutex.Unlock()
-	if fake.AssociateSpaceDeveloperStub != nil {
-		return fake.AssociateSpaceDeveloperStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.associateSpaceDeveloperReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -702,15 +708,16 @@ func (fake *FakeCFClient) AssociateSpaceManager(arg1 string, arg2 string) (cfcli
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.AssociateSpaceManagerStub
+	fakeReturns := fake.associateSpaceManagerReturns
 	fake.recordInvocation("AssociateSpaceManager", []interface{}{arg1, arg2})
 	fake.associateSpaceManagerMutex.Unlock()
-	if fake.AssociateSpaceManagerStub != nil {
-		return fake.AssociateSpaceManagerStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.associateSpaceManagerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -765,15 +772,16 @@ func (fake *FakeCFClient) DeleteUser(arg1 string) error {
 	fake.deleteUserArgsForCall = append(fake.deleteUserArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.DeleteUserStub
+	fakeReturns := fake.deleteUserReturns
 	fake.recordInvocation("DeleteUser", []interface{}{arg1})
 	fake.deleteUserMutex.Unlock()
-	if fake.DeleteUserStub != nil {
-		return fake.DeleteUserStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteUserReturns
 	return fakeReturns.result1
 }
 
@@ -825,15 +833,16 @@ func (fake *FakeCFClient) ListOrgAuditors(arg1 string) ([]cfclient.User, error) 
 	fake.listOrgAuditorsArgsForCall = append(fake.listOrgAuditorsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListOrgAuditorsStub
+	fakeReturns := fake.listOrgAuditorsReturns
 	fake.recordInvocation("ListOrgAuditors", []interface{}{arg1})
 	fake.listOrgAuditorsMutex.Unlock()
-	if fake.ListOrgAuditorsStub != nil {
-		return fake.ListOrgAuditorsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listOrgAuditorsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -888,15 +897,16 @@ func (fake *FakeCFClient) ListOrgBillingManagers(arg1 string) ([]cfclient.User, 
 	fake.listOrgBillingManagersArgsForCall = append(fake.listOrgBillingManagersArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListOrgBillingManagersStub
+	fakeReturns := fake.listOrgBillingManagersReturns
 	fake.recordInvocation("ListOrgBillingManagers", []interface{}{arg1})
 	fake.listOrgBillingManagersMutex.Unlock()
-	if fake.ListOrgBillingManagersStub != nil {
-		return fake.ListOrgBillingManagersStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listOrgBillingManagersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -951,15 +961,16 @@ func (fake *FakeCFClient) ListOrgManagers(arg1 string) ([]cfclient.User, error) 
 	fake.listOrgManagersArgsForCall = append(fake.listOrgManagersArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListOrgManagersStub
+	fakeReturns := fake.listOrgManagersReturns
 	fake.recordInvocation("ListOrgManagers", []interface{}{arg1})
 	fake.listOrgManagersMutex.Unlock()
-	if fake.ListOrgManagersStub != nil {
-		return fake.ListOrgManagersStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listOrgManagersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1014,15 +1025,16 @@ func (fake *FakeCFClient) ListOrgUsers(arg1 string) ([]cfclient.User, error) {
 	fake.listOrgUsersArgsForCall = append(fake.listOrgUsersArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListOrgUsersStub
+	fakeReturns := fake.listOrgUsersReturns
 	fake.recordInvocation("ListOrgUsers", []interface{}{arg1})
 	fake.listOrgUsersMutex.Unlock()
-	if fake.ListOrgUsersStub != nil {
-		return fake.ListOrgUsersStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listOrgUsersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1077,15 +1089,16 @@ func (fake *FakeCFClient) ListSpaceAuditors(arg1 string) ([]cfclient.User, error
 	fake.listSpaceAuditorsArgsForCall = append(fake.listSpaceAuditorsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListSpaceAuditorsStub
+	fakeReturns := fake.listSpaceAuditorsReturns
 	fake.recordInvocation("ListSpaceAuditors", []interface{}{arg1})
 	fake.listSpaceAuditorsMutex.Unlock()
-	if fake.ListSpaceAuditorsStub != nil {
-		return fake.ListSpaceAuditorsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listSpaceAuditorsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1140,15 +1153,16 @@ func (fake *FakeCFClient) ListSpaceDevelopers(arg1 string) ([]cfclient.User, err
 	fake.listSpaceDevelopersArgsForCall = append(fake.listSpaceDevelopersArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListSpaceDevelopersStub
+	fakeReturns := fake.listSpaceDevelopersReturns
 	fake.recordInvocation("ListSpaceDevelopers", []interface{}{arg1})
 	fake.listSpaceDevelopersMutex.Unlock()
-	if fake.ListSpaceDevelopersStub != nil {
-		return fake.ListSpaceDevelopersStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listSpaceDevelopersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1203,15 +1217,16 @@ func (fake *FakeCFClient) ListSpaceManagers(arg1 string) ([]cfclient.User, error
 	fake.listSpaceManagersArgsForCall = append(fake.listSpaceManagersArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListSpaceManagersStub
+	fakeReturns := fake.listSpaceManagersReturns
 	fake.recordInvocation("ListSpaceManagers", []interface{}{arg1})
 	fake.listSpaceManagersMutex.Unlock()
-	if fake.ListSpaceManagersStub != nil {
-		return fake.ListSpaceManagersStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listSpaceManagersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1266,15 +1281,16 @@ func (fake *FakeCFClient) ListSpacesByQuery(arg1 url.Values) ([]cfclient.Space, 
 	fake.listSpacesByQueryArgsForCall = append(fake.listSpacesByQueryArgsForCall, struct {
 		arg1 url.Values
 	}{arg1})
+	stub := fake.ListSpacesByQueryStub
+	fakeReturns := fake.listSpacesByQueryReturns
 	fake.recordInvocation("ListSpacesByQuery", []interface{}{arg1})
 	fake.listSpacesByQueryMutex.Unlock()
-	if fake.ListSpacesByQueryStub != nil {
-		return fake.ListSpacesByQueryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listSpacesByQueryReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1330,15 +1346,16 @@ func (fake *FakeCFClient) RemoveOrgAuditor(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RemoveOrgAuditorStub
+	fakeReturns := fake.removeOrgAuditorReturns
 	fake.recordInvocation("RemoveOrgAuditor", []interface{}{arg1, arg2})
 	fake.removeOrgAuditorMutex.Unlock()
-	if fake.RemoveOrgAuditorStub != nil {
-		return fake.RemoveOrgAuditorStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeOrgAuditorReturns
 	return fakeReturns.result1
 }
 
@@ -1391,15 +1408,16 @@ func (fake *FakeCFClient) RemoveOrgBillingManager(arg1 string, arg2 string) erro
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RemoveOrgBillingManagerStub
+	fakeReturns := fake.removeOrgBillingManagerReturns
 	fake.recordInvocation("RemoveOrgBillingManager", []interface{}{arg1, arg2})
 	fake.removeOrgBillingManagerMutex.Unlock()
-	if fake.RemoveOrgBillingManagerStub != nil {
-		return fake.RemoveOrgBillingManagerStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeOrgBillingManagerReturns
 	return fakeReturns.result1
 }
 
@@ -1452,15 +1470,16 @@ func (fake *FakeCFClient) RemoveOrgManager(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RemoveOrgManagerStub
+	fakeReturns := fake.removeOrgManagerReturns
 	fake.recordInvocation("RemoveOrgManager", []interface{}{arg1, arg2})
 	fake.removeOrgManagerMutex.Unlock()
-	if fake.RemoveOrgManagerStub != nil {
-		return fake.RemoveOrgManagerStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeOrgManagerReturns
 	return fakeReturns.result1
 }
 
@@ -1513,15 +1532,16 @@ func (fake *FakeCFClient) RemoveOrgUser(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RemoveOrgUserStub
+	fakeReturns := fake.removeOrgUserReturns
 	fake.recordInvocation("RemoveOrgUser", []interface{}{arg1, arg2})
 	fake.removeOrgUserMutex.Unlock()
-	if fake.RemoveOrgUserStub != nil {
-		return fake.RemoveOrgUserStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeOrgUserReturns
 	return fakeReturns.result1
 }
 
@@ -1574,15 +1594,16 @@ func (fake *FakeCFClient) RemoveSpaceAuditor(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RemoveSpaceAuditorStub
+	fakeReturns := fake.removeSpaceAuditorReturns
 	fake.recordInvocation("RemoveSpaceAuditor", []interface{}{arg1, arg2})
 	fake.removeSpaceAuditorMutex.Unlock()
-	if fake.RemoveSpaceAuditorStub != nil {
-		return fake.RemoveSpaceAuditorStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeSpaceAuditorReturns
 	return fakeReturns.result1
 }
 
@@ -1635,15 +1656,16 @@ func (fake *FakeCFClient) RemoveSpaceDeveloper(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RemoveSpaceDeveloperStub
+	fakeReturns := fake.removeSpaceDeveloperReturns
 	fake.recordInvocation("RemoveSpaceDeveloper", []interface{}{arg1, arg2})
 	fake.removeSpaceDeveloperMutex.Unlock()
-	if fake.RemoveSpaceDeveloperStub != nil {
-		return fake.RemoveSpaceDeveloperStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeSpaceDeveloperReturns
 	return fakeReturns.result1
 }
 
@@ -1696,15 +1718,16 @@ func (fake *FakeCFClient) RemoveSpaceManager(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RemoveSpaceManagerStub
+	fakeReturns := fake.removeSpaceManagerReturns
 	fake.recordInvocation("RemoveSpaceManager", []interface{}{arg1, arg2})
 	fake.removeSpaceManagerMutex.Unlock()
-	if fake.RemoveSpaceManagerStub != nil {
-		return fake.RemoveSpaceManagerStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeSpaceManagerReturns
 	return fakeReturns.result1
 }
 

--- a/user/fakes/fake_ldap_mgr.go
+++ b/user/fakes/fake_ldap_mgr.go
@@ -60,9 +60,10 @@ func (fake *FakeLdapManager) Close() {
 	fake.closeMutex.Lock()
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
+	if stub != nil {
 		fake.CloseStub()
 	}
 }
@@ -85,15 +86,16 @@ func (fake *FakeLdapManager) GetUserByDN(arg1 string) (*ldap.User, error) {
 	fake.getUserByDNArgsForCall = append(fake.getUserByDNArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetUserByDNStub
+	fakeReturns := fake.getUserByDNReturns
 	fake.recordInvocation("GetUserByDN", []interface{}{arg1})
 	fake.getUserByDNMutex.Unlock()
-	if fake.GetUserByDNStub != nil {
-		return fake.GetUserByDNStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getUserByDNReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -148,15 +150,16 @@ func (fake *FakeLdapManager) GetUserByID(arg1 string) (*ldap.User, error) {
 	fake.getUserByIDArgsForCall = append(fake.getUserByIDArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetUserByIDStub
+	fakeReturns := fake.getUserByIDReturns
 	fake.recordInvocation("GetUserByID", []interface{}{arg1})
 	fake.getUserByIDMutex.Unlock()
-	if fake.GetUserByIDStub != nil {
-		return fake.GetUserByIDStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getUserByIDReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -211,15 +214,16 @@ func (fake *FakeLdapManager) GetUserDNs(arg1 string) ([]string, error) {
 	fake.getUserDNsArgsForCall = append(fake.getUserDNsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetUserDNsStub
+	fakeReturns := fake.getUserDNsReturns
 	fake.recordInvocation("GetUserDNs", []interface{}{arg1})
 	fake.getUserDNsMutex.Unlock()
-	if fake.GetUserDNsStub != nil {
-		return fake.GetUserDNsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getUserDNsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/user/fakes/fake_mgr.go
+++ b/user/fakes/fake_mgr.go
@@ -155,15 +155,16 @@ func (fake *FakeManager) CleanupOrgUsers() error {
 	ret, specificReturn := fake.cleanupOrgUsersReturnsOnCall[len(fake.cleanupOrgUsersArgsForCall)]
 	fake.cleanupOrgUsersArgsForCall = append(fake.cleanupOrgUsersArgsForCall, struct {
 	}{})
+	stub := fake.CleanupOrgUsersStub
+	fakeReturns := fake.cleanupOrgUsersReturns
 	fake.recordInvocation("CleanupOrgUsers", []interface{}{})
 	fake.cleanupOrgUsersMutex.Unlock()
-	if fake.CleanupOrgUsersStub != nil {
-		return fake.CleanupOrgUsersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cleanupOrgUsersReturns
 	return fakeReturns.result1
 }
 
@@ -207,15 +208,16 @@ func (fake *FakeManager) DeinitializeLdap() error {
 	ret, specificReturn := fake.deinitializeLdapReturnsOnCall[len(fake.deinitializeLdapArgsForCall)]
 	fake.deinitializeLdapArgsForCall = append(fake.deinitializeLdapArgsForCall, struct {
 	}{})
+	stub := fake.DeinitializeLdapStub
+	fakeReturns := fake.deinitializeLdapReturns
 	fake.recordInvocation("DeinitializeLdap", []interface{}{})
 	fake.deinitializeLdapMutex.Unlock()
-	if fake.DeinitializeLdapStub != nil {
-		return fake.DeinitializeLdapStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deinitializeLdapReturns
 	return fakeReturns.result1
 }
 
@@ -262,15 +264,16 @@ func (fake *FakeManager) InitializeLdap(arg1 string, arg2 string, arg3 string) e
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.InitializeLdapStub
+	fakeReturns := fake.initializeLdapReturns
 	fake.recordInvocation("InitializeLdap", []interface{}{arg1, arg2, arg3})
 	fake.initializeLdapMutex.Unlock()
-	if fake.InitializeLdapStub != nil {
-		return fake.InitializeLdapStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.initializeLdapReturns
 	return fakeReturns.result1
 }
 
@@ -323,15 +326,16 @@ func (fake *FakeManager) ListOrgAuditors(arg1 string, arg2 *uaa.Users) (*user.Ro
 		arg1 string
 		arg2 *uaa.Users
 	}{arg1, arg2})
+	stub := fake.ListOrgAuditorsStub
+	fakeReturns := fake.listOrgAuditorsReturns
 	fake.recordInvocation("ListOrgAuditors", []interface{}{arg1, arg2})
 	fake.listOrgAuditorsMutex.Unlock()
-	if fake.ListOrgAuditorsStub != nil {
-		return fake.ListOrgAuditorsStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listOrgAuditorsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -387,15 +391,16 @@ func (fake *FakeManager) ListOrgBillingManagers(arg1 string, arg2 *uaa.Users) (*
 		arg1 string
 		arg2 *uaa.Users
 	}{arg1, arg2})
+	stub := fake.ListOrgBillingManagersStub
+	fakeReturns := fake.listOrgBillingManagersReturns
 	fake.recordInvocation("ListOrgBillingManagers", []interface{}{arg1, arg2})
 	fake.listOrgBillingManagersMutex.Unlock()
-	if fake.ListOrgBillingManagersStub != nil {
-		return fake.ListOrgBillingManagersStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listOrgBillingManagersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -451,15 +456,16 @@ func (fake *FakeManager) ListOrgManagers(arg1 string, arg2 *uaa.Users) (*user.Ro
 		arg1 string
 		arg2 *uaa.Users
 	}{arg1, arg2})
+	stub := fake.ListOrgManagersStub
+	fakeReturns := fake.listOrgManagersReturns
 	fake.recordInvocation("ListOrgManagers", []interface{}{arg1, arg2})
 	fake.listOrgManagersMutex.Unlock()
-	if fake.ListOrgManagersStub != nil {
-		return fake.ListOrgManagersStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listOrgManagersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -515,15 +521,16 @@ func (fake *FakeManager) ListSpaceAuditors(arg1 string, arg2 *uaa.Users) (*user.
 		arg1 string
 		arg2 *uaa.Users
 	}{arg1, arg2})
+	stub := fake.ListSpaceAuditorsStub
+	fakeReturns := fake.listSpaceAuditorsReturns
 	fake.recordInvocation("ListSpaceAuditors", []interface{}{arg1, arg2})
 	fake.listSpaceAuditorsMutex.Unlock()
-	if fake.ListSpaceAuditorsStub != nil {
-		return fake.ListSpaceAuditorsStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listSpaceAuditorsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -579,15 +586,16 @@ func (fake *FakeManager) ListSpaceDevelopers(arg1 string, arg2 *uaa.Users) (*use
 		arg1 string
 		arg2 *uaa.Users
 	}{arg1, arg2})
+	stub := fake.ListSpaceDevelopersStub
+	fakeReturns := fake.listSpaceDevelopersReturns
 	fake.recordInvocation("ListSpaceDevelopers", []interface{}{arg1, arg2})
 	fake.listSpaceDevelopersMutex.Unlock()
-	if fake.ListSpaceDevelopersStub != nil {
-		return fake.ListSpaceDevelopersStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listSpaceDevelopersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -643,15 +651,16 @@ func (fake *FakeManager) ListSpaceManagers(arg1 string, arg2 *uaa.Users) (*user.
 		arg1 string
 		arg2 *uaa.Users
 	}{arg1, arg2})
+	stub := fake.ListSpaceManagersStub
+	fakeReturns := fake.listSpaceManagersReturns
 	fake.recordInvocation("ListSpaceManagers", []interface{}{arg1, arg2})
 	fake.listSpaceManagersMutex.Unlock()
-	if fake.ListSpaceManagersStub != nil {
-		return fake.ListSpaceManagersStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listSpaceManagersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -705,15 +714,16 @@ func (fake *FakeManager) UpdateOrgUsers() error {
 	ret, specificReturn := fake.updateOrgUsersReturnsOnCall[len(fake.updateOrgUsersArgsForCall)]
 	fake.updateOrgUsersArgsForCall = append(fake.updateOrgUsersArgsForCall, struct {
 	}{})
+	stub := fake.UpdateOrgUsersStub
+	fakeReturns := fake.updateOrgUsersReturns
 	fake.recordInvocation("UpdateOrgUsers", []interface{}{})
 	fake.updateOrgUsersMutex.Unlock()
-	if fake.UpdateOrgUsersStub != nil {
-		return fake.UpdateOrgUsersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateOrgUsersReturns
 	return fakeReturns.result1
 }
 
@@ -757,15 +767,16 @@ func (fake *FakeManager) UpdateSpaceUsers() error {
 	ret, specificReturn := fake.updateSpaceUsersReturnsOnCall[len(fake.updateSpaceUsersArgsForCall)]
 	fake.updateSpaceUsersArgsForCall = append(fake.updateSpaceUsersArgsForCall, struct {
 	}{})
+	stub := fake.UpdateSpaceUsersStub
+	fakeReturns := fake.updateSpaceUsersReturns
 	fake.recordInvocation("UpdateSpaceUsers", []interface{}{})
 	fake.updateSpaceUsersMutex.Unlock()
-	if fake.UpdateSpaceUsersStub != nil {
-		return fake.UpdateSpaceUsersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateSpaceUsersReturns
 	return fakeReturns.result1
 }
 


### PR DESCRIPTION
This adds the ability to export space metadata labels from cf-mgmt export-config. This is useful when you want cf-mgmt apply to import the same space labels.

- Switched from using @calebwashburn fork of go-cfclient back to the latest community version (already merged the requisite APIs used by cf-mgmt).
- Removed the hardcoded metadata prefix of `cf-mgmt.pivotal.io`. This might be a breaking change, but as implemented there was no way to _not_ set a prefix (e.g. empty string).
- Only copying across labels, should probably also include annotations.