### PR TITLE
Add integration tests to ci

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -49,7 +49,7 @@ resources:
   icon: pool
   type: pcf-pool
   source:
-    api_token: ((toolsmiths))
+    api_token: ((toolsmiths.api_token))
     hostname: environments.toolsmiths.cf-app.com
     pool_name: cf-deployment
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -18,7 +18,7 @@ resources:
   type: git
   source:
     uri: git@github.com:vmwarepivotallabs/cf-mgmt.git
-    branch: add-integration-to-ci
+    branch: main
     private_key: {{git-ssh-key}}
     ignore_paths: ["README.md","docs/*"]
 
@@ -72,27 +72,15 @@ jobs:
         passed: ['claim-cf-deployment']
         trigger: true
         version: every
+    - task: unit-test
+      file: source/ci/tasks/runTests.yml
     - load_var: pooled-env
       file: cf-deployment-env/metadata
       format: json
-    - task: test
-      file: source/ci/tasks/runTests.yml
     - task: integration-test
       file: source/ci/tasks/runIntegrationTests.yml
       params:
-        CF_API_URL: ((.:pooled-env.cf.api_url))
         SYSTEM_DOMAIN: ((.:pooled-env.name)).cf-app.com
-        JUMPBOX_PRIVATE_KEY: ((.:pooled-env.bosh.jumpbox_private_key))
-        CREDHUB_CLIENT: ((.:pooled-env.bosh.credhub_client))
-        CREDHUB_SECRET: ((.:pooled-env.bosh.credhub_secret))
-        CREDHUB_CA_CERT: ((.:pooled-env.bosh.credhub_ca_cert))
-        CREDHUB_SERVER: ((.:pooled-env.bosh.credhub_server))
-        CREDHUB_PROXY: ((.:pooled-env.bosh.bosh_all_proxy))
-        BOSH_ENVIRONMENT: ((.:pooled-env.bosh.bosh_environment))
-        BOSH_CA_CERT: ((.:pooled-env.bosh.bosh_ca_cert))
-        BOSH_ALL_PROXY: ((.:pooled-env.bosh.bosh_all_proxy))
-        BOSH_CLIENT: ((.:pooled-env.bosh.bosh_client))
-        BOSH_CLIENT_SECRET: ((.:pooled-env.bosh.bosh_client_secret))
     - task: build
       file: source/ci/tasks/build.yml
     - put: draft-cfmgmt-resource
@@ -106,6 +94,10 @@ jobs:
         - compiled-output/cf-mgmt-config-linux
         - compiled-output/cf-mgmt-config-osx
         - compiled-output/cf-mgmt-config.exe
+    - put: cf-deployment-env
+      params:
+        action: unclaim
+        env_file: cf-deployment-env/metadata
 
 - name: deploy
   plan:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,17 +1,24 @@
 groups:
 - name: compile
   jobs:
+  - claim-cf-deployment
   - test-and-build
 - name: deploy
   jobs:
   - deploy
+
+resource_types:
+- name: pcf-pool
+  type: docker-image
+  source:
+    repository: cftoolsmiths/toolsmiths-envs-resource
 
 resources:
 - name: source
   type: git
   source:
     uri: git@github.com:vmwarepivotallabs/cf-mgmt.git
-    branch: main
+    branch: add-integration-to-ci
     private_key: {{git-ssh-key}}
     ignore_paths: ["README.md","docs/*"]
 
@@ -38,14 +45,54 @@ resources:
     password: {{docker-registry-password}}
     tag: {{docker-tag}}
 
+- name: cf-deployment-env
+  icon: pool
+  type: pcf-pool
+  source:
+    api_token: ((toolsmiths))
+    hostname: environments.toolsmiths.cf-app.com
+    pool_name: cf-deployment
+
 jobs:
+- name: claim-cf-deployment
+  plan:
+  - get: source
+    trigger: true
+  - put: cf-deployment-env
+    params:
+      action: claim
+
 - name: test-and-build
   plan:
     - in_parallel:
       - get: source
         trigger: true
+        passed: ['claim-cf-deployment']
+      - get: cf-deployment-env
+        passed: ['claim-cf-deployment']
+        trigger: true
+        version: every
+    - load_var: pooled-env
+      file: cf-deployment-env/metadata
+      format: json
     - task: test
       file: source/ci/tasks/runTests.yml
+    - task: integration-test
+      file: source/ci/tasks/runIntegrationTests.yml
+      params:
+        CF_API_URL: ((.:pooled-env.cf.api_url))
+        SYSTEM_DOMAIN: ((.:pooled-env.name)).cf-app.com
+        JUMPBOX_PRIVATE_KEY: ((.:pooled-env.bosh.jumpbox_private_key))
+        CREDHUB_CLIENT: ((.:pooled-env.bosh.credhub_client))
+        CREDHUB_SECRET: ((.:pooled-env.bosh.credhub_secret))
+        CREDHUB_CA_CERT: ((.:pooled-env.bosh.credhub_ca_cert))
+        CREDHUB_SERVER: ((.:pooled-env.bosh.credhub_server))
+        CREDHUB_PROXY: ((.:pooled-env.bosh.bosh_all_proxy))
+        BOSH_ENVIRONMENT: ((.:pooled-env.bosh.bosh_environment))
+        BOSH_CA_CERT: ((.:pooled-env.bosh.bosh_ca_cert))
+        BOSH_ALL_PROXY: ((.:pooled-env.bosh.bosh_all_proxy))
+        BOSH_CLIENT: ((.:pooled-env.bosh.bosh_client))
+        BOSH_CLIENT_SECRET: ((.:pooled-env.bosh.bosh_client_secret))
     - task: build
       file: source/ci/tasks/build.yml
     - put: draft-cfmgmt-resource
@@ -59,6 +106,7 @@ jobs:
         - compiled-output/cf-mgmt-config-linux
         - compiled-output/cf-mgmt-config-osx
         - compiled-output/cf-mgmt-config.exe
+
 - name: deploy
   plan:
     - in_parallel:

--- a/ci/tasks/runIntegrationTests.sh
+++ b/ci/tasks/runIntegrationTests.sh
@@ -22,5 +22,8 @@ if ! uaa-cli get-client cf-mgmt; then
 fi
 
 pushd source > /dev/null
-  RUN_INTEGRATION_TESTS=true go test ./integration/... -ginkgo.progress
+  CF_ADMIN_PASSWORD=$(get_from_credhub cf_admin_password) \
+  ADMIN_CLIENT_SECRET=$(get_from_credhub uaa_admin_client_secret) \
+  RUN_INTEGRATION_TESTS=true \
+    go test ./integration/... -ginkgo.progress
 popd

--- a/ci/tasks/runIntegrationTests.sh
+++ b/ci/tasks/runIntegrationTests.sh
@@ -2,4 +2,21 @@
 
 set -eu -o pipefail
 
-ls
+get_password_from_credhub() {
+  local variable_name=$1
+  credhub find -j -n "${variable_name}" | jq -r .credentials[].name | xargs credhub get -j -n | jq -r .value
+}
+
+go get code.cloudfoundry.org/uaa-cli
+
+uaa-cli target "https://uaa.${SYSTEM_DOMAIN}"
+uaa-cli get-client-credentials-token "admin" -s $(get_password_from_credhub cf_admin_password)
+
+uaa-cli create-client cf-mgmt \
+  --client_secret cf-mgmt-secret \
+  --authorized_grant_types client_credentials,refresh_token \
+  --authorities cloud_controller.admin,scim.read,scim.write,routing.router_groups.read
+
+pushd source > /dev/null
+  RUN_INTEGRATION_TESTS=true go test ./integration/...
+popd

--- a/ci/tasks/runIntegrationTests.sh
+++ b/ci/tasks/runIntegrationTests.sh
@@ -2,21 +2,25 @@
 
 set -eu -o pipefail
 
-get_password_from_credhub() {
+get_from_credhub() {
   local variable_name=$1
   credhub find -j -n "${variable_name}" | jq -r .credentials[].name | xargs credhub get -j -n | jq -r .value
 }
 
+eval "$(bbl print-env --metadata-file cf-deployment-env/metadata)"
+
 go get code.cloudfoundry.org/uaa-cli
 
-uaa-cli target "https://uaa.${SYSTEM_DOMAIN}"
-uaa-cli get-client-credentials-token "admin" -s $(get_password_from_credhub cf_admin_password)
+uaa-cli target "https://uaa.${SYSTEM_DOMAIN}" -k
+uaa-cli get-client-credentials-token "admin" -s $(get_from_credhub uaa_admin_client_secret)
 
-uaa-cli create-client cf-mgmt \
-  --client_secret cf-mgmt-secret \
-  --authorized_grant_types client_credentials,refresh_token \
-  --authorities cloud_controller.admin,scim.read,scim.write,routing.router_groups.read
+if ! uaa-cli get-client cf-mgmt; then
+  uaa-cli create-client cf-mgmt \
+    --client_secret cf-mgmt-secret \
+    --authorized_grant_types client_credentials,refresh_token \
+    --authorities cloud_controller.admin,scim.read,scim.write,routing.router_groups.read
+fi
 
 pushd source > /dev/null
-  RUN_INTEGRATION_TESTS=true go test ./integration/...
+  RUN_INTEGRATION_TESTS=true go test ./integration/... -ginkgo.progress
 popd

--- a/ci/tasks/runIntegrationTests.sh
+++ b/ci/tasks/runIntegrationTests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+ls

--- a/ci/tasks/runIntegrationTests.sh
+++ b/ci/tasks/runIntegrationTests.sh
@@ -26,4 +26,4 @@ pushd source > /dev/null
   ADMIN_CLIENT_SECRET=$(get_from_credhub uaa_admin_client_secret) \
   RUN_INTEGRATION_TESTS=true \
     go test ./integration/... -ginkgo.progress
-popd
+popd > /dev/null

--- a/ci/tasks/runIntegrationTests.yml
+++ b/ci/tasks/runIntegrationTests.yml
@@ -1,0 +1,15 @@
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: cloudfoundry/cf-deployment-concourse-tasks
+    tag: latest
+
+inputs:
+- name: source
+- name: cf-deployment-env
+
+run:
+  path: source/ci/tasks/runIntegrationTests.sh
+

--- a/ci/tasks/runIntegrationTests.yml
+++ b/ci/tasks/runIntegrationTests.yml
@@ -11,19 +11,7 @@ inputs:
 - name: cf-deployment-env
 
 params:
-  CF_API_URL:
   SYSTEM_DOMAIN:
-  JUMPBOX_PRIVATE_KEY:
-  CREDHUB_CLIENT:
-  CREDHUB_SECRET:
-  CREDHUB_CA_CERT:
-  CREDHUB_SERVER:
-  CREDHUB_PROXY:
-  BOSH_ENVIRONMENT:
-  BOSH_CA_CERT:
-  BOSH_ALL_PROXY:
-  BOSH_CLIENT:
-  BOSH_CLIENT_SECRET:
 
 run:
   path: source/ci/tasks/runIntegrationTests.sh

--- a/ci/tasks/runIntegrationTests.yml
+++ b/ci/tasks/runIntegrationTests.yml
@@ -10,6 +10,21 @@ inputs:
 - name: source
 - name: cf-deployment-env
 
+params:
+  CF_API_URL:
+  SYSTEM_DOMAIN:
+  JUMPBOX_PRIVATE_KEY:
+  CREDHUB_CLIENT:
+  CREDHUB_SECRET:
+  CREDHUB_CA_CERT:
+  CREDHUB_SERVER:
+  CREDHUB_PROXY:
+  BOSH_ENVIRONMENT:
+  BOSH_CA_CERT:
+  BOSH_ALL_PROXY:
+  BOSH_CLIENT:
+  BOSH_CLIENT_SECRET:
+
 run:
   path: source/ci/tasks/runIntegrationTests.sh
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -171,7 +171,7 @@ var _ = Describe("cf-mgmt cli", func() {
 					"--client-secret", "cf-mgmt-secret")
 				session, err := Start(createOrgsCommand, GinkgoWriter, GinkgoWriter)
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session).Should(Exit(0))
+				Eventually(session, time.Minute).Should(Exit(0))
 
 				orgs, err = cf("orgs")
 				Expect(err).ShouldNot(HaveOccurred())

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -14,27 +14,36 @@ import (
 )
 
 const (
-	systemDomain = "dev.cfdev.sh"
-	userId       = "admin"
-	password     = "admin"
-	clientSecret = "admin-client-secret"
-	configDir    = "./fixture"
+	configDir = "./fixture"
 )
 
 // cf runs the cf CLI with the specified args.
 func cf(args ...string) ([]byte, error) {
 	cmd := exec.Command("cf", args...)
+
 	out, err := cmd.Output()
 	if err != nil {
 		return out, fmt.Errorf("cf %s: %v", strings.Join(args, " "), err)
 	}
+
 	return out, nil
 }
 
-var outPath string
+var (
+	outPath      string
+	systemDomain string
+	userID       string
+	password     string
+	clientSecret string
+)
 
 var _ = BeforeSuite(func() {
-	_, err := cf("login", "--skip-ssl-validation", "-a", "https://api."+systemDomain, "-u", userId, "-p", password)
+	systemDomain = os.Getenv("SYSTEM_DOMAIN")
+	userID = "admin"
+	password = os.Getenv("CF_ADMIN_PASSWORD")
+	clientSecret = os.Getenv("CF_CLIENT_SECRET")
+
+	_, err := cf("login", "--skip-ssl-validation", "-a", "https://api."+systemDomain, "-u", userID, "-p", password)
 	Expect(err).ShouldNot(HaveOccurred())
 
 	outPath, err = Build("github.com/vmwarepivotallabs/cf-mgmt/cmd/cf-mgmt")
@@ -76,7 +85,7 @@ var _ = Describe("cf-mgmt cli", func() {
 				createOrgsCommand := exec.Command(outPath, "create-orgs",
 					"--config-dir", configDir,
 					"--system-domain", systemDomain,
-					"--user-id", userId,
+					"--user-id", userID,
 					"--password", password,
 					"--client-secret", clientSecret)
 				session, err := Start(createOrgsCommand, GinkgoWriter, GinkgoWriter)
@@ -92,7 +101,7 @@ var _ = Describe("cf-mgmt cli", func() {
 				deleteOrgsCommand := exec.Command(outPath, "delete-orgs",
 					"--config-dir", configDir,
 					"--system-domain", systemDomain,
-					"--user-id", userId,
+					"--user-id", userID,
 					"--password", password,
 					"--client-secret", clientSecret)
 				session, err = Start(deleteOrgsCommand, GinkgoWriter, GinkgoWriter)
@@ -109,7 +118,7 @@ var _ = Describe("cf-mgmt cli", func() {
 				createSpacesCommand := exec.Command(outPath, "create-spaces",
 					"--config-dir", configDir,
 					"--system-domain", systemDomain,
-					"--user-id", userId,
+					"--user-id", userID,
 					"--password", password,
 					"--client-secret", clientSecret)
 				session, err = Start(createSpacesCommand, GinkgoWriter, GinkgoWriter)
@@ -133,7 +142,7 @@ var _ = Describe("cf-mgmt cli", func() {
 				updateIsoSegmentsCommand := exec.Command(outPath, "isolation-segments",
 					"--config-dir", configDir,
 					"--system-domain", systemDomain,
-					"--user-id", userId,
+					"--user-id", userID,
 					"--password", password,
 					"--client-secret", clientSecret)
 				session, err = Start(updateIsoSegmentsCommand, GinkgoWriter, GinkgoWriter)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 const (
-	systemDomain = "sys.sunsetyellow.cf-app.com"
+	systemDomain = "dev.cfdev.sh"
 	userId       = "admin"
-	password     = "w-HMAh7gC13CMRwfI8Ok8AGVDMMPBu2X"
-	clientSecret = "D_vH6ABlXsXsC1jRyH_IA7R6-JSCMdtp"
+	password     = "admin"
+	clientSecret = "admin-client-secret"
 	configDir    = "./fixture"
 )
 
@@ -102,7 +102,6 @@ var _ = Describe("cf-mgmt cli", func() {
 				orgs, err = cf("orgs")
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(bytes.Contains(orgs, []byte("system"))).Should(BeTrue())
-				// Expect(bytes.Contains(orgs, []byte("cfdev-org"))).Should(BeTrue())
 				Expect(bytes.Contains(orgs, []byte("rogue-org1"))).ShouldNot(BeTrue())
 				Expect(bytes.Contains(orgs, []byte("rogue-org1"))).ShouldNot(BeTrue())
 
@@ -120,6 +119,7 @@ var _ = Describe("cf-mgmt cli", func() {
 				_, err = cf("target", "-o", "test1")
 				Expect(err).ShouldNot(HaveOccurred())
 				spaces, err := cf("spaces")
+				Expect(err).ShouldNot(HaveOccurred())
 				Expect(bytes.Contains(spaces, []byte("dev"))).Should(BeTrue())
 				Expect(bytes.Contains(spaces, []byte("prod"))).Should(BeTrue())
 
@@ -191,7 +191,6 @@ var _ = Describe("cf-mgmt cli", func() {
 				orgs, err = cf("orgs")
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(bytes.Contains(orgs, []byte("system"))).Should(BeTrue())
-				// Expect(bytes.Contains(orgs, []byte("cfdev-org"))).Should(BeTrue())
 				Expect(bytes.Contains(orgs, []byte("rogue-org1"))).ShouldNot(BeTrue())
 				Expect(bytes.Contains(orgs, []byte("rogue-org2"))).ShouldNot(BeTrue())
 
@@ -208,6 +207,7 @@ var _ = Describe("cf-mgmt cli", func() {
 				_, err = cf("target", "-o", "test1")
 				Expect(err).ShouldNot(HaveOccurred())
 				spaces, err := cf("spaces")
+				Expect(err).ShouldNot(HaveOccurred())
 				Expect(bytes.Contains(spaces, []byte("dev"))).Should(BeTrue())
 				Expect(bytes.Contains(spaces, []byte("prod"))).Should(BeTrue())
 
@@ -223,7 +223,6 @@ var _ = Describe("cf-mgmt cli", func() {
 					"--system-domain", systemDomain,
 					"--user-id", "cf-mgmt",
 					"--client-secret", "cf-mgmt-secret")
-				fmt.Println(updateIsoSegmentsCommand)
 				session, err = Start(updateIsoSegmentsCommand, GinkgoWriter, GinkgoWriter)
 				Expect(err).ShouldNot(HaveOccurred())
 				Eventually(session, time.Minute).Should(Exit(0))

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,10 +14,10 @@ import (
 )
 
 const (
-	systemDomain = "dev.cfdev.sh"
+	systemDomain = "sys.sunsetyellow.cf-app.com"
 	userId       = "admin"
-	password     = "admin"
-	clientSecret = "admin-client-secret"
+	password     = "w-HMAh7gC13CMRwfI8Ok8AGVDMMPBu2X"
+	clientSecret = "D_vH6ABlXsXsC1jRyH_IA7R6-JSCMdtp"
 	configDir    = "./fixture"
 )
 
@@ -101,7 +102,7 @@ var _ = Describe("cf-mgmt cli", func() {
 				orgs, err = cf("orgs")
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(bytes.Contains(orgs, []byte("system"))).Should(BeTrue())
-				Expect(bytes.Contains(orgs, []byte("cfdev-org"))).Should(BeTrue())
+				// Expect(bytes.Contains(orgs, []byte("cfdev-org"))).Should(BeTrue())
 				Expect(bytes.Contains(orgs, []byte("rogue-org1"))).ShouldNot(BeTrue())
 				Expect(bytes.Contains(orgs, []byte("rogue-org1"))).ShouldNot(BeTrue())
 
@@ -137,7 +138,7 @@ var _ = Describe("cf-mgmt cli", func() {
 					"--client-secret", clientSecret)
 				session, err = Start(updateIsoSegmentsCommand, GinkgoWriter, GinkgoWriter)
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session).Should(Exit(0))
+				Eventually(session, time.Minute).Should(Exit(0))
 
 				is, err := cf("isolation-segments")
 				Expect(err).ShouldNot(HaveOccurred())
@@ -190,7 +191,7 @@ var _ = Describe("cf-mgmt cli", func() {
 				orgs, err = cf("orgs")
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(bytes.Contains(orgs, []byte("system"))).Should(BeTrue())
-				Expect(bytes.Contains(orgs, []byte("cfdev-org"))).Should(BeTrue())
+				// Expect(bytes.Contains(orgs, []byte("cfdev-org"))).Should(BeTrue())
 				Expect(bytes.Contains(orgs, []byte("rogue-org1"))).ShouldNot(BeTrue())
 				Expect(bytes.Contains(orgs, []byte("rogue-org2"))).ShouldNot(BeTrue())
 
@@ -222,9 +223,10 @@ var _ = Describe("cf-mgmt cli", func() {
 					"--system-domain", systemDomain,
 					"--user-id", "cf-mgmt",
 					"--client-secret", "cf-mgmt-secret")
+				fmt.Println(updateIsoSegmentsCommand)
 				session, err = Start(updateIsoSegmentsCommand, GinkgoWriter, GinkgoWriter)
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session).Should(Exit(0))
+				Eventually(session, time.Minute).Should(Exit(0))
 
 				is, err := cf("isolation-segments")
 				Expect(err).ShouldNot(HaveOccurred())

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -41,7 +41,7 @@ var _ = BeforeSuite(func() {
 	systemDomain = os.Getenv("SYSTEM_DOMAIN")
 	userID = "admin"
 	password = os.Getenv("CF_ADMIN_PASSWORD")
-	clientSecret = os.Getenv("CF_CLIENT_SECRET")
+	clientSecret = os.Getenv("ADMIN_CLIENT_SECRET")
 
 	_, err := cf("login", "--skip-ssl-validation", "-a", "https://api."+systemDomain, "-u", userID, "-p", password)
 	Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
Hey there @mstergianis 

The integration tests are now run as part of the main pipeline with this PR. This can give us a little more confidence in changes on each commit rather than running them manually.

They are run against a live cf-deployment instead of PCFDev which is now deprecated.