### PR TITLE
[ci] Enhance pipeline to test against all supported TAS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 TAS version | Compatible?
 --- | ---
-2.12 | ![CI](https://ci.cryo.cf-app.com/api/v1/teams/cf-mgmt/pipelines/cf-mgmt/jobs/test-against-tas-2-12/badge)
+2.12 | ![CI](https://ci.cryo.cf-app.com/api/v1/teams/cf-mgmt/pipelines/cf-mgmt/jobs/test-against-tas-2_12/badge)
+2.11 | ![CI](https://ci.cryo.cf-app.com/api/v1/teams/cf-mgmt/pipelines/cf-mgmt/jobs/test-against-tas-2_11_lts2/badge)
+2.10 | ![CI](https://ci.cryo.cf-app.com/api/v1/teams/cf-mgmt/pipelines/cf-mgmt/jobs/test-against-tas-2_10/badge)
+2.7 | ![CI](https://ci.cryo.cf-app.com/api/v1/teams/cf-mgmt/pipelines/cf-mgmt/jobs/test-against-tas-2_7_lts/badge)
 
 # Cloud Foundry Management (cf-mgmt)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+TAS version | Compatible?
+--- | ---
+2.12 | ![CI](https://ci.cryo.cf-app.com/api/v1/teams/cf-mgmt/pipelines/cf-mgmt/jobs/test-against-tas-2-12/badge)
+
 # Cloud Foundry Management (cf-mgmt)
 
 Go automation for managing orgs, spaces, users (from ldap groups or internal store) mapping to roles, quotas, application security groups and private-domains that can be driven from concourse pipeline and GIT managed metadata

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,9 +1,20 @@
+---
+#! to set pipeline run: fly set-pipeline -p cf-mgmt -c <(ytt -f ci/pipeline.yml)
+
+#@ tas_versions = [
+#@   {"version": "2.12.*", "pool_without_location": "2_12"},
+#@   {"version": "2.11.*", "pool_without_location": "2_11_lts2"},
+#@   {"version": "2.10.*", "pool_without_location": "2_10"},
+#@   {"version": "2.7.*", "pool_without_location": "2_7_lts"},
+#@ ]
+
 groups:
 - name: compile
   jobs:
   - claim-cf-deployment
   - test-and-build
-  - test-against-tas-2-12
+#@ for/end v in tas_versions:
+  - #@ 'test-against-tas-' + v["pool_without_location"]
 - name: deploy
   jobs:
   - deploy
@@ -21,16 +32,26 @@ resource_types:
   type: registry-image
 
 resources:
-# This is just so that we can trigger the job everytime there's a new TAS
-# version.  It will download the tile... which is not quite nice in terms of
-# execution time and resourse consumption. Maybe there's a better way.
-- name: tas-for-vms-2-12
+#! This is just so that we can trigger the job everytime there's a new TAS
+#! version.  It will download the tile... which is not quite nice in terms of
+#! execution time and resourse consumption. Maybe there's a better way.
+#@ for/end v in tas_versions:
+- name: #@ 'tas-for-vms-' + v["pool_without_location"]
   type: pivnet
   source:
     api_token: ((pivnet.refresh_token))
     product_slug: elastic-runtime
     sort_by: semver
-    product_version: 2\.12\..*
+    product_version: #@ v["version"]
+
+#@ for/end v in tas_versions:
+- icon: pool
+  name: #@ 'tas-' + v["pool_without_location"] + '-env'
+  source:
+    api_token: ((toolsmiths.api_token))
+    hostname: environments.toolsmiths.cf-app.com
+    pool_name: #@ 'us_' + v["pool_without_location"]
+  type: pcf-pool
 
 - name: source
   type: git
@@ -70,14 +91,6 @@ resources:
     api_token: ((toolsmiths.api_token))
     hostname: environments.toolsmiths.cf-app.com
     pool_name: cf-deployment
-
-- icon: pool
-  name: tas-2-12-env
-  source:
-    api_token: ((toolsmiths.api_token))
-    hostname: environments.toolsmiths.cf-app.com
-    pool_name: us_2_12
-  type: pcf-pool
 
 - name: every-day
   type: time
@@ -138,26 +151,26 @@ jobs:
         action: unclaim
         env_file: cf-deployment-env/metadata
 
-- name: test-against-tas-2-12
+#@ for/end v in tas_versions:
+- name: #@ 'test-against-tas-' + v["pool_without_location"]
   plan:
     - in_parallel:
-      - get: tas-for-vms-2-12
+      - get: #@ 'tas-for-vms-' + v["pool_without_location"]
         trigger: true
       - get: source
         trigger: true
         resource: source
-      - put: tas-2-12-env
+      - put: #@ 'tas-' + v["pool_without_location"] +'-env'
         params:
           action: claim
     - task: integration-test
       file: source/ci/tasks/runIntegrationTestsAgainstTAS.yml
       input_mapping:
-        env: tas-2-12-env
-    - put: tas-2-12-env
+        env: #@ 'tas-' + v["pool_without_location"] +'-env'
+    - put: #@ 'tas-' + v["pool_without_location"] +'-env'
       params:
         action: unclaim
-        env_file: tas-2-12-env/metadata
-
+        env_file: #@ 'tas-' + v["pool_without_location"] +'-env/metadata'
 
 - name: deploy
   plan:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -3,6 +3,7 @@ groups:
   jobs:
   - claim-cf-deployment
   - test-and-build
+  - test-against-tas-2-12
 - name: deploy
   jobs:
   - deploy
@@ -13,7 +14,24 @@ resource_types:
   source:
     repository: cftoolsmiths/toolsmiths-envs-resource
 
+- name: pivnet
+  source:
+    repository: pivotalcf/pivnet-resource
+    tag: latest-final
+  type: registry-image
+
 resources:
+# This is just so that we can trigger the job everytime there's a new TAS
+# version.  It will download the tile... which is not quite nice in terms of
+# execution time and resourse consumption. Maybe there's a better way.
+- name: tas-for-vms-2-12
+  type: pivnet
+  source:
+    api_token: ((pivnet.refresh_token))
+    product_slug: elastic-runtime
+    sort_by: semver
+    product_version: 2\.12\..*
+
 - name: source
   type: git
   source:
@@ -52,6 +70,14 @@ resources:
     api_token: ((toolsmiths.api_token))
     hostname: environments.toolsmiths.cf-app.com
     pool_name: cf-deployment
+
+- icon: pool
+  name: tas-2-12-env
+  source:
+    api_token: ((toolsmiths.api_token))
+    hostname: environments.toolsmiths.cf-app.com
+    pool_name: us_2_12
+  type: pcf-pool
 
 - name: every-day
   type: time
@@ -111,6 +137,27 @@ jobs:
       params:
         action: unclaim
         env_file: cf-deployment-env/metadata
+
+- name: test-against-tas-2-12
+  plan:
+    - in_parallel:
+      - get: tas-for-vms-2-12
+        trigger: true
+      - get: source
+        trigger: true
+        resource: source
+      - put: tas-2-12-env
+        params:
+          action: claim
+    - task: integration-test
+      file: source/ci/tasks/runIntegrationTestsAgainstTAS.yml
+      input_mapping:
+        env: tas-2-12-env
+    - put: tas-2-12-env
+      params:
+        action: unclaim
+        env_file: tas-2-12-env/metadata
+
 
 - name: deploy
   plan:

--- a/ci/tasks/runIntegrationTestsAgainstTAS.sh
+++ b/ci/tasks/runIntegrationTestsAgainstTAS.sh
@@ -5,13 +5,7 @@ set -eu -o pipefail
 [ -d env ]
 [ -d source ]
 
-apt-get update
-apt-get install wget gnupg -y
-
-wget -q -O - https://raw.githubusercontent.com/starkandwayne/homebrew-cf/master/public.key | apt-key add -
-echo "deb http://apt.starkandwayne.com stable main" | tee /etc/apt/sources.list.d/starkandwayne.list
-apt-get update
-apt-get install om -y
+: "${SYSTEM_DOMAIN:="$(jq -r '.sys_domain' env/metadata)"}"
 
 ADMIN_CLIENT_SECRET="$( \
   om \
@@ -22,12 +16,6 @@ ADMIN_CLIENT_SECRET="$( \
       --credential-reference .uaa.admin_client_credentials \
       --credential-field password \
 )"
-
-go get code.cloudfoundry.org/uaa-cli
-
-SYSTEM_DOMAIN="$(jq -r '.sys_domain' env/metadata)"
-uaa-cli target "https://uaa.${SYSTEM_DOMAIN}" -k
-uaa-cli get-client-credentials-token "admin" -s "$ADMIN_CLIENT_SECRET"
 
 if ! uaa-cli get-client cf-mgmt; then
   uaa-cli create-client cf-mgmt \
@@ -45,10 +33,6 @@ CF_ADMIN_PASSWORD="$( \
       --credential-reference .uaa.admin_credentials \
       --credential-field password \
 )"
-
-curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github&version=v6" | tar -zx
-mv cf /usr/local/bin
-cf -v
 
 pushd source > /dev/null
   export ADMIN_CLIENT_SECRET CF_ADMIN_PASSWORD SYSTEM_DOMAIN

--- a/ci/tasks/runIntegrationTestsAgainstTAS.sh
+++ b/ci/tasks/runIntegrationTestsAgainstTAS.sh
@@ -17,12 +17,15 @@ ADMIN_CLIENT_SECRET="$( \
       --credential-field password \
 )"
 
-if ! uaac get-client cf-mgmt; then
-  uaac create-client cf-mgmt \
-    --client_secret cf-mgmt-secret \
-    --authorized_grant_types client_credentials,refresh_token \
-    --authorities cloud_controller.admin,scim.read,scim.write,routing.router_groups.read
-fi
+uaac target "uaa.$SYSTEM_DOMAIN" --skip-ssl-validation
+uaac token client get admin -s "$ADMIN_CLIENT_SECRET"
+
+uaac client delete cf-mgmt || true
+uaac client add cf-mgmt \
+  --name cf-mgmt \
+  --secret cf-mgmt-secret \
+  --authorized_grant_types client_credentials,refresh_token \
+  --authorities cloud_controller.admin,scim.read,scim.write,routing.router_groups.read
 
 CF_ADMIN_PASSWORD="$( \
   om \

--- a/ci/tasks/runIntegrationTestsAgainstTAS.sh
+++ b/ci/tasks/runIntegrationTestsAgainstTAS.sh
@@ -51,7 +51,7 @@ mv cf /usr/local/bin
 cf -v
 
 pushd source > /dev/null
-  export ADMIN_CLIENT_SECRET CF_ADMIN_PASSWORD
+  export ADMIN_CLIENT_SECRET CF_ADMIN_PASSWORD SYSTEM_DOMAIN
 
   RUN_INTEGRATION_TESTS=true \
     go test ./integration/... -ginkgo.progress

--- a/ci/tasks/runIntegrationTestsAgainstTAS.sh
+++ b/ci/tasks/runIntegrationTestsAgainstTAS.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+[ -d env ]
+[ -d source ]
+
+apt-get update
+apt-get install wget gnupg -y
+
+wget -q -O - https://raw.githubusercontent.com/starkandwayne/homebrew-cf/master/public.key | apt-key add -
+echo "deb http://apt.starkandwayne.com stable main" | tee /etc/apt/sources.list.d/starkandwayne.list
+apt-get update
+apt-get install om -y
+
+ADMIN_CLIENT_SECRET="$( \
+  om \
+    --skip-ssl-validation \
+    --env env/pcf.yml \
+    credentials \
+      --product-name cf \
+      --credential-reference .uaa.admin_client_credentials \
+      --credential-field password \
+)"
+
+go get code.cloudfoundry.org/uaa-cli
+
+SYSTEM_DOMAIN="$(jq -r '.sys_domain' env/metadata)"
+uaa-cli target "https://uaa.${SYSTEM_DOMAIN}" -k
+uaa-cli get-client-credentials-token "admin" -s "$ADMIN_CLIENT_SECRET"
+
+if ! uaa-cli get-client cf-mgmt; then
+  uaa-cli create-client cf-mgmt \
+    --client_secret cf-mgmt-secret \
+    --authorized_grant_types client_credentials,refresh_token \
+    --authorities cloud_controller.admin,scim.read,scim.write,routing.router_groups.read
+fi
+
+CF_ADMIN_PASSWORD="$( \
+  om \
+    --skip-ssl-validation \
+    --env env/pcf.yml \
+    credentials \
+      --product-name cf \
+      --credential-reference .uaa.admin_credentials \
+      --credential-field password \
+)"
+
+curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github&version=v6" | tar -zx
+mv cf /usr/local/bin
+cf -v
+
+pushd source > /dev/null
+  export ADMIN_CLIENT_SECRET CF_ADMIN_PASSWORD
+
+  RUN_INTEGRATION_TESTS=true \
+    go test ./integration/... -ginkgo.progress
+popd > /dev/null

--- a/ci/tasks/runIntegrationTestsAgainstTAS.sh
+++ b/ci/tasks/runIntegrationTestsAgainstTAS.sh
@@ -17,8 +17,8 @@ ADMIN_CLIENT_SECRET="$( \
       --credential-field password \
 )"
 
-if ! uaa-cli get-client cf-mgmt; then
-  uaa-cli create-client cf-mgmt \
+if ! uaac get-client cf-mgmt; then
+  uaac create-client cf-mgmt \
     --client_secret cf-mgmt-secret \
     --authorized_grant_types client_credentials,refresh_token \
     --authorities cloud_controller.admin,scim.read,scim.write,routing.router_groups.read

--- a/ci/tasks/runIntegrationTestsAgainstTAS.yml
+++ b/ci/tasks/runIntegrationTestsAgainstTAS.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: cryogenics/essentials+cf6
+    repository: cryogenics/essentials-cf6
     tag: latest
 
 inputs:

--- a/ci/tasks/runIntegrationTestsAgainstTAS.yml
+++ b/ci/tasks/runIntegrationTestsAgainstTAS.yml
@@ -1,0 +1,15 @@
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: cloudfoundry/cf-deployment-concourse-tasks
+    tag: latest
+
+inputs:
+- name: source
+- name: env
+
+run:
+  path: source/ci/tasks/runIntegrationTestsAgainstTAS.sh
+

--- a/ci/tasks/runIntegrationTestsAgainstTAS.yml
+++ b/ci/tasks/runIntegrationTestsAgainstTAS.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: cloudfoundry/cf-deployment-concourse-tasks
+    repository: cryogenics/essentials+cf6
     tag: latest
 
 inputs:


### PR DESCRIPTION
- `ytt` is not required to set pipelines: `fly set-pipeline -p cf-mgmt -c <(ytt -f ci/pipeline.yml)`
- it is now possible to validate compatibility at a glance using README