### PR TITLE
Stop testing unsupported versions

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -5,8 +5,6 @@
 #@   {"version": "2.13.*", "pool_without_location": "2_13"},
 #@   {"version": "2.12.*", "pool_without_location": "2_12"},
 #@   {"version": "2.11.*", "pool_without_location": "2_11_lts2"},
-#@   {"version": "2.10.*", "pool_without_location": "2_10"},
-#@   {"version": "2.7.*", "pool_without_location": "2_7_lts"},
 #@ ]
 
 groups:


### PR DESCRIPTION
[#182318385]

- [2.7 reached EOGS on 2022-04-30 ](https://network.pivotal.io/products/elastic-runtime/#/releases/1120148)
- [2.10 reached EOGS on 2022-03-31](https://network.pivotal.io/products/elastic-runtime/#/releases/1120183)