### PR TITLE
Use Ubuntu LTS as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM concourse/buildroot:git
-
-MAINTAINER Caleb Washburn "cwashburn@pivotal.io"
+FROM ubuntu:latest
 
 COPY cf-mgmt-linux /usr/bin/cf-mgmt
 COPY cf-mgmt-config-linux /usr/bin/cf-mgmt-config


### PR DESCRIPTION
- Current base image is `concourse/buildroot` which has not been updated for [6 years](https://hub.docker.com/r/concourse/buildroot)
- Also removed @calebwashburn from the maintainers list as we understand @vmware-tanzu-labs/cryogenics is the official maintainer