### PR TITLE
chore: remove usage of ioutil package

### DIFF
--- a/config/file_utils.go
+++ b/config/file_utils.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,7 +36,7 @@ func FileOrDirectoryExists(path string) bool {
 
 //LoadFileBytes - Load a file and return the bytes
 func LoadFileBytes(path string) ([]byte, error) {
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error reading file %s", path)
 	}
@@ -47,7 +46,7 @@ func LoadFileBytes(path string) ([]byte, error) {
 //LoadFile -
 func LoadFile(configFile string, dataType interface{}) error {
 	var data []byte
-	data, err := ioutil.ReadFile(configFile)
+	data, err := os.ReadFile(configFile)
 	if err != nil {
 		return errors.Wrapf(err, "Error reading file %s", configFile)
 	}
@@ -60,7 +59,7 @@ func LoadFile(configFile string, dataType interface{}) error {
 
 //WriteFileBytes -
 func WriteFileBytes(configFile string, data []byte) error {
-	return ioutil.WriteFile(configFile, data, 0755)
+	return os.WriteFile(configFile, data, 0755)
 }
 
 //WriteFile -

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -44,7 +43,7 @@ func (m *yamlManager) GetDefaultASGConfigs() ([]ASGConfig, error) {
 	var result []ASGConfig
 	for _, securityGroupFile := range files {
 		lo.G.Debug("Loading security group contents", securityGroupFile)
-		bytes, err := ioutil.ReadFile(securityGroupFile)
+		bytes, err := os.ReadFile(securityGroupFile)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error reading file %s", securityGroupFile)
 		}
@@ -71,7 +70,7 @@ func (m *yamlManager) GetASGConfigs() ([]ASGConfig, error) {
 	var result []ASGConfig
 	for _, securityGroupFile := range files {
 		lo.G.Debug("Loading security group contents", securityGroupFile)
-		bytes, err := ioutil.ReadFile(securityGroupFile)
+		bytes, err := os.ReadFile(securityGroupFile)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error reading file %s", securityGroupFile)
 		}
@@ -194,7 +193,7 @@ func (m *yamlManager) GetSpaceConfigs() ([]SpaceConfig, error) {
 		if result[i].EnableSecurityGroup {
 			securityGroupFile := strings.Replace(f, "spaceConfig.yml", "security-group.json", -1)
 			lo.G.Debug("Loading security group contents", securityGroupFile)
-			bytes, err := ioutil.ReadFile(securityGroupFile)
+			bytes, err := os.ReadFile(securityGroupFile)
 			if err != nil {
 				return nil, err
 			}

--- a/config/yaml_config_test.go
+++ b/config/yaml_config_test.go
@@ -2,7 +2,6 @@ package config_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -189,7 +188,7 @@ var _ = Describe("CF-Mgmt Config", func() {
 			}
 			spaces := &config.Spaces{Org: orgName}
 			BeforeEach(func() {
-				tempDir, err = ioutil.TempDir("", "cf-mgmt")
+				tempDir, err = os.MkdirTemp("", "cf-mgmt")
 				Expect(err).ShouldNot(HaveOccurred())
 				configManager = config.NewManager(path.Join(tempDir, "cfmgmt"))
 				configManager.CreateConfigIfNotExists("ldap")
@@ -371,7 +370,7 @@ var _ = Describe("CF-Mgmt Config", func() {
 				var err error
 				var configManager config.Manager
 				BeforeEach(func() {
-					tempDir, err = ioutil.TempDir("", "cf-mgmt")
+					tempDir, err = os.MkdirTemp("", "cf-mgmt")
 					Expect(err).ShouldNot(HaveOccurred())
 					configManager = config.NewManager(path.Join(tempDir, "cfmgmt"))
 					configManager.CreateConfigIfNotExists("ldap")
@@ -484,7 +483,7 @@ var _ = Describe("CF-Mgmt Config", func() {
 
 			BeforeEach(func() {
 				var err error
-				tempDir, err = ioutil.TempDir("", "cf-mgmt")
+				tempDir, err = os.MkdirTemp("", "cf-mgmt")
 				Expect(err).ShouldNot(HaveOccurred())
 				configManager = config.NewManager(path.Join(tempDir, "cfmgmt"))
 				configManager.CreateConfigIfNotExists("ldap")

--- a/configcommands/generate_concourse_pipeline.go
+++ b/configcommands/generate_concourse_pipeline.go
@@ -3,7 +3,6 @@ package configcommands
 import (
 	"fmt"
 	"github.com/vmwarepivotallabs/cf-mgmt/embedded"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -74,7 +73,7 @@ func (c *GenerateConcoursePipelineCommand) createFile(assetName, fileName string
 	if strings.HasSuffix(fileName, ".sh") {
 		perm = 0755
 	}
-	return ioutil.WriteFile(path.Join(c.TargetDirectory, fileName), bytes, perm)
+	return os.WriteFile(path.Join(c.TargetDirectory, fileName), bytes, perm)
 }
 
 func (c *GenerateConcoursePipelineCommand) createTaskYml() error {
@@ -85,7 +84,7 @@ func (c *GenerateConcoursePipelineCommand) createTaskYml() error {
 	}
 	perm := os.FileMode(0666)
 	versioned := strings.Replace(string(bytes), "~VERSION~", version, -1)
-	return ioutil.WriteFile(filepath.Join(c.TargetDirectory, "ci", "tasks", "cf-mgmt.yml"), []byte(versioned), perm)
+	return os.WriteFile(filepath.Join(c.TargetDirectory, "ci", "tasks", "cf-mgmt.yml"), []byte(versioned), perm)
 }
 
 func (c *GenerateConcoursePipelineCommand) createVarsYml() error {
@@ -95,5 +94,5 @@ func (c *GenerateConcoursePipelineCommand) createVarsYml() error {
 	}
 	perm := os.FileMode(0666)
 	processedBytes := strings.Replace(string(bytes), "~CONFIGDIR~", c.ConfigDirectory, -1)
-	return ioutil.WriteFile(filepath.Join(c.ConfigDirectory, "vars.yml"), []byte(processedBytes), perm)
+	return os.WriteFile(filepath.Join(c.ConfigDirectory, "vars.yml"), []byte(processedBytes), perm)
 }

--- a/ldap_integration/ldap_test.go
+++ b/ldap_integration/ldap_test.go
@@ -1,7 +1,6 @@
 package ldap_integration_test
 
 import (
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -146,7 +145,7 @@ var _ = Describe("Ldap", func() {
 
 			Context("GetLdapUser()", func() {
 				It("then it should return 1 user", func() {
-					data, _ := ioutil.ReadFile("./fixtures/user1.txt")
+					data, _ := os.ReadFile("./fixtures/user1.txt")
 					user, err := ldapManager.GetUserByDN(string(data))
 					Expect(err).Should(BeNil())
 					Expect(user).ShouldNot(BeNil())


### PR DESCRIPTION
Although this package is supported, it is deprecated and there are alternatives in other places in the standard libary.