### PR TITLE
source secrets from cerberus

### DIFF
--- a/ci/pipelines/cf-mgmt/pipeline.yml
+++ b/ci/pipelines/cf-mgmt/pipeline.yml
@@ -54,6 +54,7 @@ var_sources:
     auth_params: *cerberus
     url: *cerberus_url
     path_prefix: secret
+    lookup_templates: ["/{{.Pipeline}}/{{.Secret}}", "/{{.Secret}}"]
 groups:
 - name: test
   jobs:


### PR DESCRIPTION
[#186322733]

fix lookup_templates. The default didn't work because our custom vault doesn't prefix secrets with `./cryogenics`