### PR TITLE
adding linux arm64 build artefacts.

### DIFF
--- a/ci/pipelines/cf-mgmt/pipeline.yml
+++ b/ci/pipelines/cf-mgmt/pipeline.yml
@@ -407,9 +407,11 @@ jobs:
       tag: compiled-output/tag
       globs:
       - compiled-output/cf-mgmt-linux
+      - compiled-output/cf-mgmt-linux-arm64
       - compiled-output/cf-mgmt-osx
       - compiled-output/cf-mgmt.exe
       - compiled-output/cf-mgmt-config-linux
+      - compiled-output/cf-mgmt-config-linux-arm64
       - compiled-output/cf-mgmt-config-osx
       - compiled-output/cf-mgmt-config.exe
   - load_var: github-release-url

--- a/ci/tasks/build.sh
+++ b/ci/tasks/build.sh
@@ -40,10 +40,12 @@ cp -R ${SOURCE_DIR}/* ${WORKING_DIR}/.
 
 pushd ${WORKING_DIR} > /dev/null
   CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ${OUTPUT_DIR}/cf-mgmt-linux -ldflags "-X github.com/vmwarepivotallabs/cf-mgmt/configcommands.VERSION=${VERSION} -X github.com/vmwarepivotallabs/cf-mgmt/configcommands.COMMIT=${COMMIT}" cmd/cf-mgmt/main.go
+  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ${OUTPUT_DIR}/cf-mgmt-linux-arm64 -ldflags "-X github.com/vmwarepivotallabs/cf-mgmt/configcommands.VERSION=${VERSION} -X github.com/vmwarepivotallabs/cf-mgmt/configcommands.COMMIT=${COMMIT}" cmd/cf-mgmt/main.go
   GOOS=darwin GOARCH=amd64 go build -o ${OUTPUT_DIR}/cf-mgmt-osx -ldflags "-X github.com/vmwarepivotallabs/cf-mgmt/configcommands.VERSION=${VERSION} -X github.com/vmwarepivotallabs/cf-mgmt/configcommands.COMMIT=${COMMIT}" cmd/cf-mgmt/main.go
   GOOS=windows GOARCH=amd64 go build -o ${OUTPUT_DIR}/cf-mgmt.exe -ldflags "-X github.com/vmwarepivotallabs/cf-mgmt/configcommands.VERSION=${VERSION} -X github.com/vmwarepivotallabs/cf-mgmt/configcommands.COMMIT=${COMMIT}" cmd/cf-mgmt/main.go
 
   CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ${OUTPUT_DIR}/cf-mgmt-config-linux -ldflags "-X github.com/vmwarepivotallabs/cf-mgmt/configcommands.VERSION=${VERSION} -X github.com/vmwarepivotallabs/cf-mgmt/configcommands.COMMIT=${COMMIT}" cmd/cf-mgmt-config/main.go
+  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ${OUTPUT_DIR}/cf-mgmt-config-linux-arm64 -ldflags "-X github.com/vmwarepivotallabs/cf-mgmt/configcommands.VERSION=${VERSION} -X github.com/vmwarepivotallabs/cf-mgmt/configcommands.COMMIT=${COMMIT}" cmd/cf-mgmt-config/main.go
   GOOS=darwin GOARCH=amd64 go build -o ${OUTPUT_DIR}/cf-mgmt-config-osx -ldflags "-X github.com/vmwarepivotallabs/cf-mgmt/configcommands.VERSION=${VERSION} -X github.com/vmwarepivotallabs/cf-mgmt/configcommands.COMMIT=${COMMIT}" cmd/cf-mgmt-config/main.go
   GOOS=windows GOARCH=amd64 go build -o ${OUTPUT_DIR}/cf-mgmt-config.exe -ldflags "-X github.com/vmwarepivotallabs/cf-mgmt/configcommands.VERSION=${VERSION} -X github.com/vmwarepivotallabs/cf-mgmt/configcommands.COMMIT=${COMMIT}" cmd/cf-mgmt-config/main.go
 


### PR DESCRIPTION
Hi

I am wondering if it would be possible to build a linux arm64 build for Linux as well.
I hope this pull request does create the needed artefacts.

Use case it solves:
Users with M1 OSX can use native architecture in VM's running linux by using cf-mgmt-linux-arm64 or cf-mgmt-config-linux-arm64 with images based on aarch64 architecture.

Have a nice day.