### PR TITLE
all bumpers should be serial

### DIFF
--- a/ci/pipelines/cf-mgmt/pipeline.yml
+++ b/ci/pipelines/cf-mgmt/pipeline.yml
@@ -472,6 +472,7 @@ jobs:
       PIPELINE_TO_CHECK: ./pipeline-repo/ci/pipelines/cf-mgmt/pipeline.yml
 
 - name: bump-ci-tasks
+  serial: true
   plan:
   - in_parallel:
     - get: cryogenics-essentials
@@ -511,6 +512,7 @@ jobs:
       source-repo: source-write-only
 
 - name: bump-go-module
+  serial: true
   plan:
   - in_parallel:
     - get: every-day


### PR DESCRIPTION
[#187071309]
they currently force push. That created issues when the same job got triggered twice ( for unknown reasons ) and job n-1 "overtook" job n ( n used a newer HEAD ) and force pushed over the changes made by n.