### PR TITLE
Performance Improvement user sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ make-binary.sh
 test-for-pagination.sh
 export-cli.sh
 docker.env
+create-users

--- a/role/fakes/fake_cf_user_client.go
+++ b/role/fakes/fake_cf_user_client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/cloudfoundry-community/go-cfclient/v3/client"
 	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
 	"github.com/vmwarepivotallabs/cf-mgmt/role"
 )
@@ -25,18 +24,18 @@ type FakeCFUserClient struct {
 		result1 string
 		result2 error
 	}
-	ListAllStub        func(context.Context, *client.UserListOptions) ([]*resource.User, error)
-	listAllMutex       sync.RWMutex
-	listAllArgsForCall []struct {
+	GetStub        func(context.Context, string) (*resource.User, error)
+	getMutex       sync.RWMutex
+	getArgsForCall []struct {
 		arg1 context.Context
-		arg2 *client.UserListOptions
+		arg2 string
 	}
-	listAllReturns struct {
-		result1 []*resource.User
+	getReturns struct {
+		result1 *resource.User
 		result2 error
 	}
-	listAllReturnsOnCall map[int]struct {
-		result1 []*resource.User
+	getReturnsOnCall map[int]struct {
+		result1 *resource.User
 		result2 error
 	}
 	invocations      map[string][][]interface{}
@@ -108,17 +107,17 @@ func (fake *FakeCFUserClient) DeleteReturnsOnCall(i int, result1 string, result2
 	}{result1, result2}
 }
 
-func (fake *FakeCFUserClient) ListAll(arg1 context.Context, arg2 *client.UserListOptions) ([]*resource.User, error) {
-	fake.listAllMutex.Lock()
-	ret, specificReturn := fake.listAllReturnsOnCall[len(fake.listAllArgsForCall)]
-	fake.listAllArgsForCall = append(fake.listAllArgsForCall, struct {
+func (fake *FakeCFUserClient) Get(arg1 context.Context, arg2 string) (*resource.User, error) {
+	fake.getMutex.Lock()
+	ret, specificReturn := fake.getReturnsOnCall[len(fake.getArgsForCall)]
+	fake.getArgsForCall = append(fake.getArgsForCall, struct {
 		arg1 context.Context
-		arg2 *client.UserListOptions
+		arg2 string
 	}{arg1, arg2})
-	stub := fake.ListAllStub
-	fakeReturns := fake.listAllReturns
-	fake.recordInvocation("ListAll", []interface{}{arg1, arg2})
-	fake.listAllMutex.Unlock()
+	stub := fake.GetStub
+	fakeReturns := fake.getReturns
+	fake.recordInvocation("Get", []interface{}{arg1, arg2})
+	fake.getMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
 	}
@@ -128,47 +127,47 @@ func (fake *FakeCFUserClient) ListAll(arg1 context.Context, arg2 *client.UserLis
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeCFUserClient) ListAllCallCount() int {
-	fake.listAllMutex.RLock()
-	defer fake.listAllMutex.RUnlock()
-	return len(fake.listAllArgsForCall)
+func (fake *FakeCFUserClient) GetCallCount() int {
+	fake.getMutex.RLock()
+	defer fake.getMutex.RUnlock()
+	return len(fake.getArgsForCall)
 }
 
-func (fake *FakeCFUserClient) ListAllCalls(stub func(context.Context, *client.UserListOptions) ([]*resource.User, error)) {
-	fake.listAllMutex.Lock()
-	defer fake.listAllMutex.Unlock()
-	fake.ListAllStub = stub
+func (fake *FakeCFUserClient) GetCalls(stub func(context.Context, string) (*resource.User, error)) {
+	fake.getMutex.Lock()
+	defer fake.getMutex.Unlock()
+	fake.GetStub = stub
 }
 
-func (fake *FakeCFUserClient) ListAllArgsForCall(i int) (context.Context, *client.UserListOptions) {
-	fake.listAllMutex.RLock()
-	defer fake.listAllMutex.RUnlock()
-	argsForCall := fake.listAllArgsForCall[i]
+func (fake *FakeCFUserClient) GetArgsForCall(i int) (context.Context, string) {
+	fake.getMutex.RLock()
+	defer fake.getMutex.RUnlock()
+	argsForCall := fake.getArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeCFUserClient) ListAllReturns(result1 []*resource.User, result2 error) {
-	fake.listAllMutex.Lock()
-	defer fake.listAllMutex.Unlock()
-	fake.ListAllStub = nil
-	fake.listAllReturns = struct {
-		result1 []*resource.User
+func (fake *FakeCFUserClient) GetReturns(result1 *resource.User, result2 error) {
+	fake.getMutex.Lock()
+	defer fake.getMutex.Unlock()
+	fake.GetStub = nil
+	fake.getReturns = struct {
+		result1 *resource.User
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeCFUserClient) ListAllReturnsOnCall(i int, result1 []*resource.User, result2 error) {
-	fake.listAllMutex.Lock()
-	defer fake.listAllMutex.Unlock()
-	fake.ListAllStub = nil
-	if fake.listAllReturnsOnCall == nil {
-		fake.listAllReturnsOnCall = make(map[int]struct {
-			result1 []*resource.User
+func (fake *FakeCFUserClient) GetReturnsOnCall(i int, result1 *resource.User, result2 error) {
+	fake.getMutex.Lock()
+	defer fake.getMutex.Unlock()
+	fake.GetStub = nil
+	if fake.getReturnsOnCall == nil {
+		fake.getReturnsOnCall = make(map[int]struct {
+			result1 *resource.User
 			result2 error
 		})
 	}
-	fake.listAllReturnsOnCall[i] = struct {
-		result1 []*resource.User
+	fake.getReturnsOnCall[i] = struct {
+		result1 *resource.User
 		result2 error
 	}{result1, result2}
 }
@@ -178,8 +177,8 @@ func (fake *FakeCFUserClient) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.deleteMutex.RLock()
 	defer fake.deleteMutex.RUnlock()
-	fake.listAllMutex.RLock()
-	defer fake.listAllMutex.RUnlock()
+	fake.getMutex.RLock()
+	defer fake.getMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/role/fakes/fake_manager.go
+++ b/role/fakes/fake_manager.go
@@ -128,6 +128,26 @@ type FakeManager struct {
 	deleteUserReturnsOnCall map[int]struct {
 		result1 error
 	}
+	InitializeOrgUserRolesMapStub        func() error
+	initializeOrgUserRolesMapMutex       sync.RWMutex
+	initializeOrgUserRolesMapArgsForCall []struct {
+	}
+	initializeOrgUserRolesMapReturns struct {
+		result1 error
+	}
+	initializeOrgUserRolesMapReturnsOnCall map[int]struct {
+		result1 error
+	}
+	InitializeSpaceUserRolesMapStub        func() error
+	initializeSpaceUserRolesMapMutex       sync.RWMutex
+	initializeSpaceUserRolesMapArgsForCall []struct {
+	}
+	initializeSpaceUserRolesMapReturns struct {
+		result1 error
+	}
+	initializeSpaceUserRolesMapReturnsOnCall map[int]struct {
+		result1 error
+	}
 	ListOrgUsersByRoleStub        func(string) (*role.RoleUsers, *role.RoleUsers, *role.RoleUsers, *role.RoleUsers, error)
 	listOrgUsersByRoleMutex       sync.RWMutex
 	listOrgUsersByRoleArgsForCall []struct {
@@ -822,6 +842,112 @@ func (fake *FakeManager) DeleteUserReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeManager) InitializeOrgUserRolesMap() error {
+	fake.initializeOrgUserRolesMapMutex.Lock()
+	ret, specificReturn := fake.initializeOrgUserRolesMapReturnsOnCall[len(fake.initializeOrgUserRolesMapArgsForCall)]
+	fake.initializeOrgUserRolesMapArgsForCall = append(fake.initializeOrgUserRolesMapArgsForCall, struct {
+	}{})
+	stub := fake.InitializeOrgUserRolesMapStub
+	fakeReturns := fake.initializeOrgUserRolesMapReturns
+	fake.recordInvocation("InitializeOrgUserRolesMap", []interface{}{})
+	fake.initializeOrgUserRolesMapMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeManager) InitializeOrgUserRolesMapCallCount() int {
+	fake.initializeOrgUserRolesMapMutex.RLock()
+	defer fake.initializeOrgUserRolesMapMutex.RUnlock()
+	return len(fake.initializeOrgUserRolesMapArgsForCall)
+}
+
+func (fake *FakeManager) InitializeOrgUserRolesMapCalls(stub func() error) {
+	fake.initializeOrgUserRolesMapMutex.Lock()
+	defer fake.initializeOrgUserRolesMapMutex.Unlock()
+	fake.InitializeOrgUserRolesMapStub = stub
+}
+
+func (fake *FakeManager) InitializeOrgUserRolesMapReturns(result1 error) {
+	fake.initializeOrgUserRolesMapMutex.Lock()
+	defer fake.initializeOrgUserRolesMapMutex.Unlock()
+	fake.InitializeOrgUserRolesMapStub = nil
+	fake.initializeOrgUserRolesMapReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeManager) InitializeOrgUserRolesMapReturnsOnCall(i int, result1 error) {
+	fake.initializeOrgUserRolesMapMutex.Lock()
+	defer fake.initializeOrgUserRolesMapMutex.Unlock()
+	fake.InitializeOrgUserRolesMapStub = nil
+	if fake.initializeOrgUserRolesMapReturnsOnCall == nil {
+		fake.initializeOrgUserRolesMapReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.initializeOrgUserRolesMapReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeManager) InitializeSpaceUserRolesMap() error {
+	fake.initializeSpaceUserRolesMapMutex.Lock()
+	ret, specificReturn := fake.initializeSpaceUserRolesMapReturnsOnCall[len(fake.initializeSpaceUserRolesMapArgsForCall)]
+	fake.initializeSpaceUserRolesMapArgsForCall = append(fake.initializeSpaceUserRolesMapArgsForCall, struct {
+	}{})
+	stub := fake.InitializeSpaceUserRolesMapStub
+	fakeReturns := fake.initializeSpaceUserRolesMapReturns
+	fake.recordInvocation("InitializeSpaceUserRolesMap", []interface{}{})
+	fake.initializeSpaceUserRolesMapMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeManager) InitializeSpaceUserRolesMapCallCount() int {
+	fake.initializeSpaceUserRolesMapMutex.RLock()
+	defer fake.initializeSpaceUserRolesMapMutex.RUnlock()
+	return len(fake.initializeSpaceUserRolesMapArgsForCall)
+}
+
+func (fake *FakeManager) InitializeSpaceUserRolesMapCalls(stub func() error) {
+	fake.initializeSpaceUserRolesMapMutex.Lock()
+	defer fake.initializeSpaceUserRolesMapMutex.Unlock()
+	fake.InitializeSpaceUserRolesMapStub = stub
+}
+
+func (fake *FakeManager) InitializeSpaceUserRolesMapReturns(result1 error) {
+	fake.initializeSpaceUserRolesMapMutex.Lock()
+	defer fake.initializeSpaceUserRolesMapMutex.Unlock()
+	fake.InitializeSpaceUserRolesMapStub = nil
+	fake.initializeSpaceUserRolesMapReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeManager) InitializeSpaceUserRolesMapReturnsOnCall(i int, result1 error) {
+	fake.initializeSpaceUserRolesMapMutex.Lock()
+	defer fake.initializeSpaceUserRolesMapMutex.Unlock()
+	fake.InitializeSpaceUserRolesMapStub = nil
+	if fake.initializeSpaceUserRolesMapReturnsOnCall == nil {
+		fake.initializeSpaceUserRolesMapReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.initializeSpaceUserRolesMapReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeManager) ListOrgUsersByRole(arg1 string) (*role.RoleUsers, *role.RoleUsers, *role.RoleUsers, *role.RoleUsers, error) {
 	fake.listOrgUsersByRoleMutex.Lock()
 	ret, specificReturn := fake.listOrgUsersByRoleReturnsOnCall[len(fake.listOrgUsersByRoleArgsForCall)]
@@ -1501,6 +1627,10 @@ func (fake *FakeManager) Invocations() map[string][][]interface{} {
 	defer fake.clearRolesMutex.RUnlock()
 	fake.deleteUserMutex.RLock()
 	defer fake.deleteUserMutex.RUnlock()
+	fake.initializeOrgUserRolesMapMutex.RLock()
+	defer fake.initializeOrgUserRolesMapMutex.RUnlock()
+	fake.initializeSpaceUserRolesMapMutex.RLock()
+	defer fake.initializeSpaceUserRolesMapMutex.RUnlock()
 	fake.listOrgUsersByRoleMutex.RLock()
 	defer fake.listOrgUsersByRoleMutex.RUnlock()
 	fake.listSpaceUsersByRoleMutex.RLock()

--- a/role/manager_org_test.go
+++ b/role/manager_org_test.go
@@ -182,10 +182,9 @@ var _ = Describe("given RoleManager", func() {
 		})
 		Context("Remove", func() {
 			BeforeEach(func() {
-				uaaFake.ListUsersReturns([]uaaclient.User{}, uaaclient.Page{StartIndex: 1, TotalResults: 0, ItemsPerPage: 500}, nil)
-				userClient.ListAllReturns([]*resource.User{
-					{GUID: "test-user-guid"},
-				}, nil)
+				uaaFake.ListUsersReturns([]uaaclient.User{
+					{ID: "test-user-guid", Username: "test"},
+				}, uaaclient.Page{StartIndex: 1, TotalResults: 1, ItemsPerPage: 500}, nil)
 				roleClient.ListAllReturns([]*resource.Role{
 					{
 						GUID: "role-guid-auditor",

--- a/role/manager_space_test.go
+++ b/role/manager_space_test.go
@@ -39,10 +39,9 @@ var _ = Describe("given RoleManager", func() {
 
 		Context("Remove", func() {
 			BeforeEach(func() {
-				uaaFake.ListUsersReturns([]uaaclient.User{}, uaaclient.Page{StartIndex: 1, TotalResults: 0, ItemsPerPage: 500}, nil)
-				userClient.ListAllReturns([]*resource.User{
-					{GUID: "test-user-guid"},
-				}, nil)
+				uaaFake.ListUsersReturns([]uaaclient.User{
+					{ID: "test-user-guid", Username: "test"},
+				}, uaaclient.Page{StartIndex: 1, TotalResults: 1, ItemsPerPage: 500}, nil)
 				roleClient.ListAllReturns([]*resource.Role{
 					{
 						GUID: "role-guid-auditor",

--- a/role/manager_test.go
+++ b/role/manager_test.go
@@ -2,22 +2,29 @@ package role_test
 
 import (
 	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
+	uaaclient "github.com/cloudfoundry-community/go-uaa"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/vmwarepivotallabs/cf-mgmt/role"
 	"github.com/vmwarepivotallabs/cf-mgmt/role/fakes"
+	uaafakes "github.com/vmwarepivotallabs/cf-mgmt/uaa/fakes"
 )
 
 var _ = Describe("given RoleManager", func() {
 	var (
 		roleManager *DefaultManager
 		roleClient  *fakes.FakeCFRoleClient
+		uaaFake     = new(uaafakes.FakeUaa)
 	)
 	BeforeEach(func() {
 		roleClient = new(fakes.FakeCFRoleClient)
+		uaaFake = new(uaafakes.FakeUaa)
 	})
 	Context("Role Manager", func() {
 		BeforeEach(func() {
+			uaaFake.ListUsersReturns([]uaaclient.User{
+				{ID: "test-user-guid", Username: "test"},
+			}, uaaclient.Page{StartIndex: 1, TotalResults: 1, ItemsPerPage: 500}, nil)
 			roleManager = &DefaultManager{
 				RoleClient: roleClient,
 			}

--- a/role/role_users.go
+++ b/role/role_users.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
 	"github.com/vmwarepivotallabs/cf-mgmt/uaa"
 	"github.com/xchapter7x/lo"
 )
@@ -16,7 +15,7 @@ func InitRoleUsers() *RoleUsers {
 	}
 }
 
-func NewRoleUsers(users []*resource.User, uaaUsers *uaa.Users) (*RoleUsers, error) {
+func NewRoleUsers(users []*uaa.User, uaaUsers *uaa.Users) (*RoleUsers, error) {
 	roleUsers := InitRoleUsers()
 	for _, user := range users {
 		uaaUser := uaaUsers.GetByID(user.GUID)

--- a/role/types.go
+++ b/role/types.go
@@ -20,7 +20,9 @@ type RoleUser struct {
 type Manager interface {
 	ClearRoles()
 	DeleteUser(userGuid string) error
+	InitializeSpaceUserRolesMap() error
 	ListSpaceUsersByRole(spaceGUID string) (*RoleUsers, *RoleUsers, *RoleUsers, *RoleUsers, error)
+	InitializeOrgUserRolesMap() error
 	ListOrgUsersByRole(orgGUID string) (*RoleUsers, *RoleUsers, *RoleUsers, *RoleUsers, error)
 	AssociateOrgAuditor(orgGUID, orgName, entityGUID, userName, userGUID string) error
 	AssociateOrgManager(orgGUID, orgName, entityGUID, userName, userGUID string) error
@@ -50,8 +52,8 @@ type CFRoleClient interface {
 }
 
 type CFUserClient interface {
-	ListAll(ctx context.Context, opts *v3cfclient.UserListOptions) ([]*resource.User, error)
 	Delete(ctx context.Context, guid string) (string, error)
+	Get(ctx context.Context, guid string) (*resource.User, error)
 }
 
 type CFJobClient interface {

--- a/uaa/uaa.go
+++ b/uaa/uaa.go
@@ -119,7 +119,7 @@ func (m *DefaultUAAManager) ListUsers() (*Users, error) {
 	}
 
 	users := &Users{}
-	lo.G.Debug("Getting users from Cloud Foundry")
+	lo.G.Debug("Getting users from UAA")
 	userList, err := m.ListAllUsers()
 	if err != nil {
 		var requestError uaaclient.RequestError
@@ -142,7 +142,9 @@ func (m *DefaultUAAManager) ListUsers() (*Users, error) {
 			GUID:       user.ID,
 		})
 	}
+
 	m.Users = users
+
 	return users, nil
 }
 

--- a/user/ldap_users_test.go
+++ b/user/ldap_users_test.go
@@ -3,7 +3,6 @@ package user_test
 import (
 	"errors"
 
-	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
 	uaaclient "github.com/cloudfoundry-community/go-uaa"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -67,7 +66,7 @@ var _ = Describe("given UserSpaces", func() {
 
 				users, err := userManager.UAAMgr.ListUsers()
 				Expect(err).ShouldNot(HaveOccurred())
-				roleUsers, _ = role.NewRoleUsers([]*resource.User{
+				roleUsers, _ = role.NewRoleUsers([]*uaa.User{
 					{Username: "test_ldap", GUID: "test_ldap-id"},
 				}, users)
 
@@ -118,7 +117,7 @@ var _ = Describe("given UserSpaces", func() {
 
 				users, err := userManager.UAAMgr.ListUsers()
 				Expect(err).ShouldNot(HaveOccurred())
-				roleUsers, _ = role.NewRoleUsers([]*resource.User{
+				roleUsers, _ = role.NewRoleUsers([]*uaa.User{
 					{Username: "test_ldap", GUID: "test_ldap-id"},
 				}, users)
 

--- a/user/saml_users_test.go
+++ b/user/saml_users_test.go
@@ -3,7 +3,6 @@ package user_test
 import (
 	"errors"
 
-	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
 	uaaclient "github.com/cloudfoundry-community/go-uaa"
 	"github.com/vmwarepivotallabs/cf-mgmt/config"
 	configfakes "github.com/vmwarepivotallabs/cf-mgmt/config/fakes"
@@ -63,7 +62,7 @@ var _ = Describe("SamlUsers", func() {
 			users, err := userManager.UAAMgr.ListUsers()
 			Expect(err).ShouldNot(HaveOccurred())
 			roleUsers, _ = role.NewRoleUsers(
-				[]*resource.User{
+				[]*uaa.User{
 					{Username: "Test.Test@test.com", GUID: "test-id"},
 				},
 				users,
@@ -189,7 +188,7 @@ var _ = Describe("SamlUsers", func() {
 			users, err := userManager.UAAMgr.ListUsers()
 			Expect(err).ShouldNot(HaveOccurred())
 			roleUsers, _ = role.NewRoleUsers(
-				[]*resource.User{
+				[]*uaa.User{
 					{Username: "test.test@test.com", GUID: "test-id", Origin: "saml_original_origin"},
 				},
 				users,

--- a/user/users.go
+++ b/user/users.go
@@ -68,6 +68,10 @@ func (m *DefaultManager) GetUAAUsers() (*uaa.Users, error) {
 func (m *DefaultManager) UpdateSpaceUsers() []error {
 	errs := []error{}
 	m.RoleMgr.ClearRoles()
+	err := m.RoleMgr.InitializeSpaceUserRolesMap()
+	if err != nil {
+		return []error{err}
+	}
 	spaceConfigs, err := m.Cfg.GetSpaceConfigs()
 	if err != nil {
 		return []error{err}
@@ -182,6 +186,10 @@ func (m *DefaultManager) updateSpaceUsers(input *config.SpaceConfig) error {
 func (m *DefaultManager) UpdateOrgUsers() []error {
 	errs := []error{}
 	m.RoleMgr.ClearRoles()
+	err := m.RoleMgr.InitializeOrgUserRolesMap()
+	if err != nil {
+		return []error{err}
+	}
 	orgConfigs, err := m.Cfg.GetOrgConfigs()
 	if err != nil {
 		return []error{err}

--- a/user/users_test.go
+++ b/user/users_test.go
@@ -65,7 +65,7 @@ var _ = Describe("given UserSpaces", func() {
 
 				users, err := userManager.UAAMgr.ListUsers()
 				Expect(err).ShouldNot(HaveOccurred())
-				roleUsers, _ = role.NewRoleUsers([]*resource.User{
+				roleUsers, _ = role.NewRoleUsers([]*uaa.User{
 					{Username: "test-existing", GUID: "test-existing-id"},
 				}, users)
 			})
@@ -155,7 +155,7 @@ var _ = Describe("given UserSpaces", func() {
 			BeforeEach(func() {
 				uaaUsers := &uaa.Users{}
 				uaaUsers.Add(uaa.User{Username: "test", Origin: "uaa", GUID: "test-id"})
-				roleUsers, _ = role.NewRoleUsers([]*resource.User{
+				roleUsers, _ = role.NewRoleUsers([]*uaa.User{
 					{Username: "test", GUID: "test-id"},
 				}, uaaUsers)
 			})
@@ -199,7 +199,7 @@ var _ = Describe("given UserSpaces", func() {
 			It("Should skip users that match protected user pattern", func() {
 				uaaUsers := &uaa.Users{}
 				uaaUsers.Add(uaa.User{Username: "abcd_123_0919191", Origin: "uaa", GUID: "test-id"})
-				roleUsers, _ = role.NewRoleUsers([]*resource.User{
+				roleUsers, _ = role.NewRoleUsers([]*uaa.User{
 					{Username: "abcd_123_0919191", GUID: "test-id"},
 				}, uaaUsers)
 				updateUsersInput := UsersInput{
@@ -291,7 +291,7 @@ var _ = Describe("given UserSpaces", func() {
 
 				users, err := userManager.UAAMgr.ListUsers()
 				Expect(err).ShouldNot(HaveOccurred())
-				roleUsers, _ = role.NewRoleUsers([]*resource.User{}, users)
+				roleUsers, _ = role.NewRoleUsers([]*uaa.User{}, users)
 
 			})
 			It("Should add internal user to role and ldap user with same name to role", func() {


### PR DESCRIPTION
Removing dependency on pagination of users via /v3/users endpoint and instead pulling users directly from uaa to avoid multiple api calls from cloud controller to uaa to fetch user names and other attributes not stored in the cloud controller database.  

Performance for 5000 users to do a sync when no roles have changed went from ~60 seconds to ~5 seconds.