### PR TITLE
feature: adding arm64 globs in release

### DIFF
--- a/ci/pipelines/cf-mgmt/pipeline.yml
+++ b/ci/pipelines/cf-mgmt/pipeline.yml
@@ -406,10 +406,12 @@ jobs:
       - compiled-output/cf-mgmt-linux
       - compiled-output/cf-mgmt-linux-arm64
       - compiled-output/cf-mgmt-osx
+      - compiled-output/cf-mgmt-osx-arm64
       - compiled-output/cf-mgmt.exe
       - compiled-output/cf-mgmt-config-linux
-      - compiled-output/cf-mgmt-linux-arm64
+      - compiled-output/cf-mgmt-config-linux-arm64
       - compiled-output/cf-mgmt-config-osx
+      - compiled-output/cf-mgmt-config-osx-arm64
       - compiled-output/cf-mgmt-config.exe
   - load_var: github-release-url
     file: releases/url


### PR DESCRIPTION
including arm64 for osx and linux in both cf-mgmt and cf-mgmt-config

[#187597749]