### PR TITLE
Use image-cryogenics-essentials for integration-test

### DIFF
--- a/ci/pipelines/cf-mgmt/pipeline.yml
+++ b/ci/pipelines/cf-mgmt/pipeline.yml
@@ -104,14 +104,6 @@ resources:
     uri: https://github.com/bosh-packages/golang-release.git
     tag_filter: v*
 
-- name: cf-deployment-concourse-tasks-image
-  type: registry-image
-  source:
-    repository: us-west2-docker.pkg.dev/mapbu-cryogenics/dockerhub-proxy-cache/cloudfoundry/cf-deployment-concourse-tasks
-    username: _json_key
-    password: *gcr_viewer_key
-    tag: latest
-
 - name: image-cryogenics-essentials
   type: registry-image
   source:
@@ -263,7 +255,6 @@ jobs:
       passed: [ claim-cf ]
     - get: cryogenics-concourse-tasks
     - get: image-cryogenics-essentials
-    - get: cf-deployment-concourse-tasks-image
   - in_parallel:
     - do:
       - task: unit-test
@@ -274,8 +265,8 @@ jobs:
         file: cf-deployment-env/metadata
         format: json
       - task: integration-test
-        image: cf-deployment-concourse-tasks-image
-        file: source/ci/tasks/runIntegrationTests.yml #!requires uaa cli, not available in cryo essentials
+        image: image-cryogenics-essentials
+        file: source/ci/tasks/runIntegrationTests.yml
   on_failure:
     put: pull-request
     params:

--- a/ci/tasks/runIntegrationTests.sh
+++ b/ci/tasks/runIntegrationTests.sh
@@ -18,6 +18,7 @@ eval "$(bbl print-env --metadata-file cf-deployment-env/metadata)"
 
 go version
 go install code.cloudfoundry.org/uaa-cli@latest
+export PATH=$PATH:$(go env GOPATH)/bin
 
 if [ -z "$SYSTEM_DOMAIN" ]
 then

--- a/ci/tasks/runIntegrationTests.yml
+++ b/ci/tasks/runIntegrationTests.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: cloudfoundry/cf-deployment-concourse-tasks
+    repository: harbor-repo.vmware.com/cryogenics/essentials
     tag: latest
 
 inputs:


### PR DESCRIPTION
Comment says cf-deployment-concourse-tasks-image was used since image-cryogenics-essentials does not include uaa-cli 

cf-deployment-concourse-tasks-image has an old version of Go

But the script runIntegrationTests.sh runs
`go install code.cloudfoundry.org/uaa-cli@latest`
