### PR TITLE
Add TAS 7 Pre-release to ci

### DIFF
--- a/ci/pipelines/cf-mgmt/values.yml
+++ b/ci/pipelines/cf-mgmt/values.yml
@@ -1,8 +1,8 @@
 ---
-# Automatically generated file. DO NOT EDIT.
 tas_versions:
     - {'version_slug': '2-11', 'pool_name': 'tas-2_11' , 'pivnet_ert_windows': '^2\.11\.\d+((-alpha|-beta|-rc)\.\d+)?(\+LTS-T)?$' }
     - {'version_slug': '2-13', 'pool_name': 'tas-2_13' , 'pivnet_ert_windows': '^2\.13\.\d+((-alpha|-beta|-rc)\.\d+)?(\+LTS-T)?$' }
     - {'version_slug': '4-0', 'pool_name': 'tas_four' , 'pivnet_ert_windows': '^4\.0\.\d+((-alpha|-beta|-rc)\.\d+)?(\+LTS-T)?$' }
     - {'version_slug': '5-0', 'pool_name': 'tas-5_0' , 'pivnet_ert_windows': '^5\.0\.\d+((-alpha|-beta|-rc)\.\d+)?(\+LTS-T)?$' }
     - {'version_slug': '6-0', 'pool_name': 'tas-6_0' , 'pivnet_ert_windows': '^6\.0\.\d+((-alpha|-beta|-rc)\.\d+)?(\+LTS-T)?$' }
+    - {'version_slug': '7-0', 'pool_name': 'tas_7_prerelease' , 'pivnet_ert_windows': '^7\.0\.\d+((-alpha|-beta|-rc)\.\d+)?(\+LTS-T)?$' }


### PR DESCRIPTION
According to past maintainers, the auto update was not ported. Therefore, this file is no longer autogenerated, so removed the comment.