### PR TITLE
fix: issue #579 (space roles not exported)

### DIFF
--- a/export/exportconfig.go
+++ b/export/exportconfig.go
@@ -401,7 +401,7 @@ func (im *Manager) processSpaces(globalConfig *config.GlobalConfig, orgConfig *c
 
 		spaceConfig := &config.SpaceConfig{Org: orgConfig.Org, Space: spaceName, EnableUnassignSecurityGroup: true}
 		//Add users
-		err = im.addSpaceUsers(spaceConfig, orgSpace.Relationships.Organization.Data.GUID)
+		err = im.addSpaceUsers(spaceConfig, orgSpace.GUID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- The `addSpaceUsers` function needs the space GUID as a function param, but instead the org GUID is supplied, resulting in no space users being found as the supplied space GUID (which is actually an org GUI) does not actually exist. This commit fixes this issue by correctly supplying the space GUID.
  - this commit reverses [a past change](https://github.com/vmware-tanzu-labs/cf-mgmt/commit/1483b66fe83a7fbea70304e478818e07731ecb56#diff-9982210b028e54f7afea530e407e1544509635e4dae9d236e2045280589b6b65L371) which lacks clear justification (so presumably it's an unintentional change).
- backfill an integration test that would have caught this regression.

[fixes #579]
[https://vmw-jira.broadcom.net/browse/TPCF-27431]