### PR TITLE
fix documentation of global command option `no-access-plan`

### DIFF
--- a/configcommands/global.go
+++ b/configcommands/global.go
@@ -168,5 +168,5 @@ type GlobalServiceAccess struct {
 	LimitedAccessPlan string   `long:"limited-access-plan" description:"Plan to give limited access to, must also provide org list"`
 	OrgsToAdd         []string `long:"org" description:"Orgs to add to limited plan"`
 	OrgsToRemove      []string `long:"remove-org" description:"Orgs to remove from limited plan"`
-	NoAccessPlan      string   `long:"no-access-plan" description:"Plan to give access to all orgs"`
+	NoAccessPlan      string   `long:"no-access-plan" description:"Plan to ensure no access for any org"`
 }

--- a/docs/config/global/README.md
+++ b/docs/config/global/README.md
@@ -8,10 +8,10 @@
 
 ```
 Usage:
-  main [OPTIONS] global [global-OPTIONS]
+  cf-mgmt-config [OPTIONS] global [global-OPTIONS]
 
 Help Options:
-  -h, --help                                              Show this help message
+  -h, --help                                        Show this help message
 
 [global command options]
     --config-dir=                                   Name of the config directory (default: config) [$CONFIG_DIR]
@@ -33,11 +33,11 @@ Help Options:
     --remove-shared-domain=                         Shared Domain to remove
 
     service-access:
-      --broker=                                       Name of Broker
-      --service=                                      Name of Service
-      --all-access-plan=                              Plan to give access to all orgs
-      --limited-access-plan=                          Plan to give limited access to, must also provide org list
-      --org=                                          Orgs to add to limited plan
-      --remove-org=                                   Orgs to remove from limited plan
-      --no-access-plan=                               Plan to give access to all orgs
+      --broker=                                     Name of Broker
+      --service=                                    Name of Service
+      --all-access-plan=                            Plan to give access to all orgs
+      --limited-access-plan=                        Plan to give limited access to, must also provide org list
+      --org=                                        Orgs to add to limited plan
+      --remove-org=                                 Orgs to remove from limited plan
+      --no-access-plan=                             Plan to ensure no access for any org
 ```


### PR DESCRIPTION
Recreation of https://github.com/vmware-tanzu-labs/cf-mgmt/pull/498, which was the fix for https://github.com/vmware-tanzu-labs/cf-mgmt/issues/238, so as to rerun the CI job to satisfy the PR check.